### PR TITLE
Fix for Message.create which was being called from Client.send

### DIFF
--- a/smtp/client.js
+++ b/smtp/client.js
@@ -70,7 +70,7 @@ Client.prototype =
 		var self = this;
 
 		if(!(msg instanceof message.Message) && msg.from && msg.to && msg.text)
-			msg = message.create(msg.text, msg);
+			msg = message.create(msg);
 
 		if(msg instanceof message.Message && msg.valid())
 		{

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -285,7 +285,7 @@ MessageStream.prototype.destroySoon = function()
 util.inherits(MessageStream, stream.Stream);
 
 exports.Message = Message;
-exports.create = function(text, headers) 
+exports.create = function(headers) 
 {
-	return new Message(text, headers);
+	return new Message(headers);
 };


### PR DESCRIPTION
The Message.create method was doing something wonkers when calling the Message constructor - instead of passing just headers, it passed headers.text and headers. Additionally, the create method was being called from Client.send which seemingly correctly passed the text and headers separately.

This breaks the "text only emails" example from the Readme (keeps giving the "message is not a valid Message instance" error) since in that example the message is created implicitly from the Client.send method. Other examples work as intended since the create method is called directly, passing the headers in place of the text field.

I'm guessing you wanted to refine the API but some loose ends remained. This is a great library and it would be a shame if the first example didn't work as it should.
