### PR TITLE
Index out of range bug for sending attachments

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -146,7 +146,11 @@ var MessageStream = function(message)
 			self.emit('data', ["--", boundary, CRLF].join(""));
 			output_process(function() { output_alternatives(next); });
 		}
-		else if(index < self.message.attachments.length)
+		else if(index == -1 && !self.message.html)
+		{
+			next();
+		}
+		else if(index >= 0 && index < self.message.attachments.length)
 		{
 			self.emit('data', ["--", boundary, CRLF].join(""));
 			output_process(function() { output_attachment(self.message.attachments[index], next); });


### PR DESCRIPTION
I'm trying to send an attachment and was surprised that it didn't work. My test case is a simple email with an attachment (but without the alternative html message).

Without the changes I made, the "-1" index was being passed to the  output_attachment(self.message.attachments[index]) because self.message.html was not true (no html alternative). Consequently, an undefined parameter was passed to the output_attachment which messed stuff up.

P.S. I see that some other unrelated commits are grouped with this pull request, not sure why I can make them go away :). But those commits won't mess anything up since you either incorporated those changes or the commits don't do anything (merges of my repository with your master branch).

Cheers!
