### PR TITLE
Fix for base64 encoding of attachments

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -195,6 +195,7 @@ var MessageStream = function(message)
 		
 		var chunk	= 5700;
 		var buffer 	= new Buffer(chunk);
+		var att_string	= "";
 		var opened 	= function(err, fd)
 		{
 			if(!err)
@@ -213,13 +214,19 @@ var MessageStream = function(message)
 					{
 						if(bytes == chunk)
 						{
-							self.emit('data', buffer.toString("base64"));
+							att_string += buffer.toString("base64");
 							fs.read(fd, buffer, 0, chunk, null, read);
 						}
 						else
 						{
-							self.emit('data', buffer.slice(0, bytes).toString("base64"));
-							self.emit('data', [CRLF, CRLF].join("")); // important!
+							att_string += buffer.slice(0, bytes).toString("base64");
+							
+							for (var start = 0; start < att_string.length; start += 76)
+							{
+								self.emit('data', att_string.substring(start, start + 76) + CRLF);
+							}
+							
+							self.emit('data', CRLF); // important!
 							fs.close(fd, next);
 						}
 					}


### PR DESCRIPTION
I've discovered this issue by accident. I'm using emailjs "in production" for a system at my university which sends students their PDF homework assignments via e-mail. Receivers of e-mails were able to download and open the attachment using common e-mail clients (gmail, thunderbird) but couldn't using some other clients (outlook web access for ms exchange) since the attachment was corrupted (a few bytes were missing). After quite a bit of digging, I found out that the difference between emailjs and other common clients for sending e-mails was that other clients (e.g. thunderbird and gmail) insert a CRLF after every 76 characters in the base64 encoding in the attachment. When sending attachments using common e-mail clients, attachments are never corrupted, regardless of which client was used for receiving e-mails and downloading attachments. Conclusion: it seems that most clients, like gmail, can handle situations when there aren't CRLFs every 76 chars, but some clients can't. 

So, here's what's up...

Base64 RFC (http://tools.ietf.org/html/rfc4648) says:

"Implementations MUST NOT add line feeds to base-encoded data unless the specification referring to this document explicitly directs base encoders to add line feeds after a specific number of characters."

However, MIME RFC (http://tools.ietf.org/html/rfc2045) says (about Base64 Content-Transfer-Encoding):

"The encoded output stream must be represented in lines of no more than 76 characters each."

Since node's Base64 encoder does not add line feeds when encoding, this should be done manually when encoding e-mail attachments. 

With this change, all e-mail clients I've tested with have correctly received and processed attachments sent using emailjs.
