### PR TITLE
Version 1.0.8 of buffertools does not npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
    },
    "dependencies":
    {
-      "buffertools" : ">= 1.0.5"
+      "buffertools" : ">= 1.0.5 < 1.0.8"
    },
    "engine": 		["node >= 0.3.8"],
    "main": 			"email",


### PR DESCRIPTION
I updated the package.json to >= 1.0.5 < 1.0.8 for buffertools.
