### PR TITLE
Switch to bufferjs from buffertools.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
    },
    "dependencies":
    {
-      "buffertools" : ">= 1.0.8"
+      "bufferjs" : ">= 1.0.2"
    },
    "engine": 		["node >= 0.6.15"],
    "main": 			"email",

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -2,8 +2,9 @@ var stream     = require('stream');
 var util       = require('util');
 var fs         = require('fs');
 var os         = require('os');
-var buffertools= require('buffertools');
 var path       = require('path');
+require('bufferjs');
+
 var CRLF       = "\r\n";
 var MIMECHUNK  = 76; // MIME standard wants 76 char chunks when sending out.
 var BASE64CHUNK= 24; // BASE64 bits needed before padding is used
@@ -343,7 +344,7 @@ var MessageStream = function(message)
             // do we have bytes from a previous stream data event?
             if(previous)
             {
-               var buffer2 = buffertools.concat(previous, buffer);
+               var buffer2 = Buffer.concat(previous, buffer);
                previous    = null; // free up the buffer
                buffer      = null; // free up the buffer
                buffer      = buffer2;


### PR DESCRIPTION
Buffertools doesn't work on Windows ever since 0.8.0 came out, due to TooTallNate/node-gyp#90. Moving to a JS module instead of a native one seems like a big win, anyway.

If you are concerned about the speed implications, we could maybe make buffertools an `optionalDependency` and fall back to bufferjs. But I doubt benchmarks would show much difference?
