### PR TITLE
Fix test command line on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
    "main": 			"email",
    "scripts":
    {
-       "test": "mocha -R spec -t 5000 test/*.js"
+       "test": "mocha -R spec -t 5000"
    }
 }


### PR DESCRIPTION
Globs don't work great there, and test/*.js is the default pattern anyway.
