### PR TITLE
Add .npmignore and tighten up .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules
-test/config.js
+/node_modules/
+/test/config.js
+/npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+/node_modules/
+/test/
+/.gitignore
+/.npmignore
+/.travis.yml
+/npm-debug.log


### PR DESCRIPTION
In particular, npm-debug.log is now ignored, and the tests + .travis.yml aren't included in the npm package.
