### PR TITLE
Fix for two conditional statements relating to address parsing in smtp/address.js

### DIFF
--- a/smtp/address.js
+++ b/smtp/address.js
@@ -93,7 +93,7 @@ Address.prototype =
 		if(this.pos >= this.field.length)
 		{
 			// Bad email address, no domain
-			if(plist)
+			if(plist.length)
 				returnlist = [{label:this.commentlist.join(SPACE), address:plist[0]}]; 
 		}
 
@@ -142,11 +142,11 @@ Address.prototype =
 
 		else
 		{
-			if(plist)
+			if(plist.length)
 				returnlist = {label:this.commentlist.join(SPACE), address:plist[0]};
 
 			else if(this.specials.indexOf(this.field[this.pos]) != -1)
-				this.post++;
+				this.pos++;
 		}
 
 		this.gotonext();


### PR DESCRIPTION
I'm attaching a pretty simple fix that prevents emailjs from getting stuck in an infinite loop (100 % CPU and increasing memory consumption until an allocation error terminates it) when it encounters an email address that is both invalid like `john@smith@example.com` and has a UTF-8 name encoded as base64 such as `"=?UTF-8?B?w7bDtsO2?="`. The problem arises from the fact that `Address.prototype.getphraselist` always returns an Array and `Boolean([])` equals `true` and not `false` (therefore testing for length of the Array instead).
