### PR TITLE
Always add a Date: header since that is required by RFC2822

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "simplesmtp": ">= 0.1.18",
     "mailparser": "0.2.27",
     "iconv": "1.1.3",
-    "dateformat" : "= 1.0.2-1.2.3"
+    "moment" : ">= 1.7.0"
    },
    "optionalDependencies":
    {

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -3,7 +3,7 @@ var util       = require('util');
 var fs         = require('fs');
 var os         = require('os');
 var path       = require('path');
-var dateformat = require('dateformat');
+var moment     = require('moment');
 var CRLF       = "\r\n";
 var MIMECHUNK  = 76; // MIME standard wants 76 char chunks when sending out.
 var BASE64CHUNK= 24; // BASE64 bits needed before padding is used
@@ -35,7 +35,7 @@ var Message = function(headers)
    var now = new Date();
    this.header       = {
       "message-id":"<" + now.getTime() + "." + (counter++) + "." + process.pid + "@" + os.hostname() +">",
-      "date":dateformat(now, "ddd, dd mmm yyyy HH:MM:ss o")
+      "date":moment().format("ddd, DD MMM YYYY HH:mm:ss ZZ")
    };
    this.content      = "text/plain; charset=utf-8";
 


### PR DESCRIPTION
In addition, if the user previously specified Date, that will override the default
