### PR TITLE
Fix incorrect date header when in a timezone with +/- 30 mins

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -35,7 +35,7 @@ var Message = function(headers)
    var now = new Date();
    this.header       = {
       "message-id":"<" + now.getTime() + "." + (counter++) + "." + process.pid + "@" + os.hostname() +">",
-      "date":moment().format("ddd, DD MMM YYYY HH:mm:ss ZZ")
+      "date":moment().format("ddd, DD MMM YYYY HH:mm:ss ") + moment().format("Z").replace(/:/, '')
    };
    this.content      = "text/plain; charset=utf-8";
 


### PR DESCRIPTION
Date headers should be like
`Tue, 15 Jan 2013 14:45:11 -0430`
but are like
`Tue, 15 Jan 2013 14:45:16 -0450`

For info on a time zone with a 30 min difference see http://www.timeanddate.com/library/abbreviations/timezones/sa/vet.html

The original bug for including the date header had it correct with dateFormat but neither the `Z` or `ZZ` in moment are quite the same. My proposed fix isn't very elegant but it seems to work.
