### PR TITLE
Disabling xoauth2 since it doesn't appear to be working with gmail

### DIFF
--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -472,7 +472,7 @@ SMTP.prototype =
          // less preferred methods.
          if(!method)
          {
-            var preferred = [AUTH_METHODS.XOAUTH2, AUTH_METHODS.CRAM_MD5, AUTH_METHODS.LOGIN, AUTH_METHODS.PLAIN];
+            var preferred = [AUTH_METHODS.CRAM_MD5, AUTH_METHODS.LOGIN, AUTH_METHODS.PLAIN, AUTH_METHODS.XOAUTH2];
    
             for(var i = 0; i < preferred.length; i++)
             {


### PR DESCRIPTION
From what I can see, the google xoauth2 specs require the token to be an access token, rather than just the user's password.

But I could be wrong, has the xoauth2 auth been tested and found to be working?
