### PR TITLE
Attachment read mode 'r+' incorrect

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -337,7 +337,7 @@ var MessageStream = function(message)
             self.emit('error', err);
       };
 
-      fs.open(attachment.path, 'r+', opened);
+      fs.open(attachment.path, 'r', opened);
    };
 
    var output_stream = function(attachment, callback)


### PR DESCRIPTION
'r' mode is fine, because you do not change the attachment as you read it.
