### PR TITLE
Added Jade template engine support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,8 +2,6 @@
 
 send emails, html and attachments (files, streams and strings) from node.js to any smtp server
 
-Now ColScript will be contributing to Emailjs!
-
 ## INSTALLING
 
 	npm install emailjs
@@ -40,7 +38,28 @@ server.send({
    subject: "testing emailjs"
 }, function(err, message) { console.log(err || message); });
 ```
+## EXAMPLE USAGE - Jade templates (NEW!)
+```javascript
+  var email = require('emailjs');
+  var server = email.server.connect({
+    user: "username",
+    password: "password",
+    host: "smtp.your-email.com",
+    port: 25, // Or your custom SMTP Port
+    ssl:   true
+  });
 
+server.send({
+    text: "Example email",
+    from: "Example <test@test.com>",
+    to: "example@example.com",
+    subject: "Sending a jade template through email ;D",
+    template: "./templates/hello.jade"
+  }, function (err, message){
+    console.log(err || message);
+  });
+
+```
 ## EXAMPLE USAGE - html emails and attachments
 
 ```javascript

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 
 send emails, html and attachments (files, streams and strings) from node.js to any smtp server
 
+Now ColScript will be contributing to Emailjs!
+
 ## INSTALLING
 
 	npm install emailjs

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
    "name": "emailjs",
-   "description": "send text/html emails and attachments (files, streams and strings) from node.js to any smtp server",
-   "version": "0.3.12",
+   "description": "Send text/html emails and attachments (files, streams and strings) from node.js to any smtp server",
+   "version": "0.4.0",
    "author": "eleith",
-   "contributors":["izuzak", "Hiverness", "mscdex", "jimmybergman"],
+   "contributors":["izuzak", "Hiverness", "mscdex", "jimmybergman", "Kurtz1993"],
    "repository":
    {
        "type": "git",
@@ -13,7 +13,8 @@
    {
     "moment" : "= 1.7.0",
     "mimelib": "0.2.14",
-    "starttls": "0.2.1"
+    "starttls": "0.2.1",
+    "jade": "^1.9.2"
    },
    "optionalDependencies":
    {

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -85,7 +85,7 @@ Client.prototype =
       if(!(msg instanceof message.Message) 
           && msg.from 
           && (msg.to || msg.cc || msg.bcc)
-          && (msg.text || this._containsInlinedHtml(msg.attachment)))
+          && (msg.text || this._containsInlinedHtml(msg.attachment) || msg.template))
          msg = message.create(msg);
 
       if(msg instanceof message.Message)

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -3,6 +3,7 @@ var util       = require('util');
 var fs         = require('fs');
 var os         = require('os');
 var path       = require('path');
+var jade       = require('jade');
 var moment     = require('moment');
 var mimelib    = require('mimelib');
 var address    = require('./address'); 
@@ -59,6 +60,7 @@ var Message = function(headers)
    this.attachments  = [];
    this.alternative  = null;
    var now = new Date();
+   var htmlText;
    this.header       = {
       "message-id":"<" + now.getTime() + "." + (counter++) + "." + process.pid + "@" + os.hostname() +">",
       "date":moment().format("ddd, DD MMM YYYY HH:mm:ss ") + moment().format("Z").replace(/:/, '')
@@ -75,6 +77,13 @@ var Message = function(headers)
       else if(header == 'text')
       {
          this.text = headers[header];
+      }
+      else if(header == 'template')
+      {
+         htmlText = fs.readFileSync(headers[header], 'utf8');
+         htmlText = jade.render(htmlText);
+         this.content = 'text/html; charset=utf8';
+         this.text = htmlText;
       }
       else if(header == "attachment" && typeof (headers[header]) == "object")
       {


### PR DESCRIPTION
## Added Jade template engine support
### Here's an example how to use a jade template with emailjs
```javascript
  var email = require('emailjs');
  var server = email.server.connect({
    user: "username",
    password: "password",
    host: "smtp.your-email.com",
    port: 25, // Or your custom SMTP Port
    ssl:   true
  });
server.send({
    text: "Example email",
    from: "Example <test@test.com>",
    to: "example@example.com",
    subject: "Sending a jade template through email ;D",
    template: "./templates/hello.jade"
  }, function (err, message){
    console.log(err || message);
  });
```