### PR TITLE
Fixed a bug where adding custom functions to Object.prototype resulte…

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -495,8 +495,8 @@ var MessageStream = function(message)
 
       for(var header in self.message.header)
       {
-         // do not output BCC in the headers...
-         if(!(/bcc/i.test(header)))
+         // do not output BCC in the headers (regex) nor custom Object.prototype functions...
+         if(!(/bcc/i.test(header)) && self.message.header.hasOwnProperty (header))
             data = data.concat([fix_header_name_case(header), ": ", self.message.header[header], CRLF]);
       }
 


### PR DESCRIPTION
…d with the source of these functions to be outputted in the mail headers. Worse, if the function contained a blank line, the line will be interpreted as the end of the headers zone resulting in some headers being outputted in the mail body (!).

This is what happens when you add functions to Object.prototype (here Object.prototype.getFullPath and Object.prototype.setFullPath are defined):
![Mail Screenshot](http://i.tuetuopay.fr/34b.png)

