### PR TITLE
bump moment version because of ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "addressparser": "^0.3.2",
     "mimelib": "0.2.14",
-    "moment": "= 1.7.0",
+    "moment": "= 2.11.2",
     "starttls": "1.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Hi!

This is a pull request which bumps `moment` version because of the latest ReDoS: https://github.com/eleith/emailjs/issues/144.