### PR TITLE
Upgraded iconv to 2.2.1. 2.16 gives build errors on Ubuntu 16.04

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai": "= 1.1.0",
     "simplesmtp": "0.3.32",
     "mailparser": "0.4.1",
-    "iconv": "2.1.6"
+    "iconv": "2.2.1"
   },
   "engine": [
     "node >= 0.10"


### PR DESCRIPTION
Upgrading to iconv@2.2.1 got me past a build error on  a lower version.

https://github.com/eleith/emailjs/issues/172
