### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   "dependencies": {
     "addressparser": "^0.3.2",
     "mimelib": "0.2.14",
-    "moment": "= 2.11.2",
+    "moment": "=2.11.2",
     "starttls": "1.0.1"
   },
   "optionalDependencies": {
     "bufferjs": "=1.1.0"
   },
   "devDependencies": {
-    "mocha": "= 1.7.4",
-    "chai": "= 1.1.0",
+    "mocha": "=1.7.4",
+    "chai": "=1.1.0",
     "simplesmtp": "0.3.32",
     "mailparser": "0.4.1",
     "iconv": "2.2.1"


### PR DESCRIPTION
I was testing node 8.0.0 RC-1 which ship with npm 5 beta and got this error while installing emailJS

My changes fix it. Hope it can be released soon to test email js with the last node js release.

The error :

```
> npm ERR! notarget No matching version found for moment@= 2.11.2
> npm ERR! notarget In most cases you or one of your dependencies are requesting
> npm ERR! notarget a package version that doesn't exist.
> npm ERR! notarget 
> npm ERR! notarget It was specified as a dependency of 'emailjs'
```