### PR TITLE
default to plain method

### DIFF
--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -492,6 +492,10 @@ SMTP.prototype = {
               break;
             }
           }
+
+          if (!method){
+            method = AUTH_METHODS.PLAIN; //default the method to plain when non is found
+          }
         }
 
         // handle bad responses from command differently


### PR DESCRIPTION
when method is not set to preferred - then it should be set to default.