### PR TITLE
Updated dependency declaration to be compatible to npm 5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   "dependencies": {
     "addressparser": "^0.3.2",
     "mimelib": "0.2.14",
-    "moment": "=2.11.2",
+    "moment": "2.11.2",
     "starttls": "1.0.1"
   },
   "optionalDependencies": {
-    "bufferjs": "=1.1.0"
+    "bufferjs": "1.1.0"
   },
   "devDependencies": {
-    "mocha": "=1.7.4",
-    "chai": "=1.1.0",
+    "mocha": "1.7.4",
+    "chai": "1.1.0",
     "simplesmtp": "0.3.32",
     "mailparser": "0.4.1",
     "iconv": "2.2.1"


### PR DESCRIPTION
Hi, I just wanted to set up a new project using a Docker container based on node 8 / npm 5, but it could not update the dependencies of emailjs because of the equal sign in the dependency declarations. I removed them and now everything works perfectly.

Can you merge this please?

Best,
Stefan