### PR TITLE
Allow null or empty message text.

### DIFF
--- a/smtp/client.js
+++ b/smtp/client.js
@@ -85,7 +85,7 @@ Client.prototype =
       if(!(msg instanceof message.Message) 
           && msg.from 
           && (msg.to || msg.cc || msg.bcc)
-          && ((msg.text && msg.text || '' != null) || this._containsInlinedHtml(msg.attachment)))
+          && ((msg.text || '' != null) || this._containsInlinedHtml(msg.attachment)))
          msg = message.create(msg);
 
       if(msg instanceof message.Message)

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -85,7 +85,7 @@ Client.prototype =
       if(!(msg instanceof message.Message) 
           && msg.from 
           && (msg.to || msg.cc || msg.bcc)
-          && (msg.text || this._containsInlinedHtml(msg.attachment)))
+          && ((msg.text && msg.text || '' != null) || this._containsInlinedHtml(msg.attachment)))
          msg = message.create(msg);
 
       if(msg instanceof message.Message)

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -64,7 +64,7 @@ var Message = function(headers)
       }
       else if(header == 'text')
       {
-         this.text = headers[header];
+         this.text = headers[header] || '';
       }
       else if(header == "attachment" && typeof (headers[header]) == "object")
       {

--- a/test/message.js
+++ b/test/message.js
@@ -82,6 +82,32 @@ describe("messages", function()
       }, done);
    });
 
+   it('null text', function(done) {
+      send({
+         subject: "this is a test TEXT message from emailjs",
+         from:    "zelda@gmail.com",
+         to:      "gannon@gmail.com",
+         text:    null,
+         "message-id": "this is a special id"
+      }, function(mail)
+      {
+         expect(mail.text).to.equal("\n\n");
+      }, done);
+   });
+
+   it('empty text', function(done) {
+      send({
+         subject: "this is a test TEXT message from emailjs",
+         from:    "zelda@gmail.com",
+         to:      "gannon@gmail.com",
+         text:    "",
+         "message-id": "this is a special id"
+      }, function(mail)
+      {
+         expect(mail.text).to.equal("\n\n");
+      }, done);
+   });
+
    it("simple unicode text message", function(done)
    {
       var message =


### PR DESCRIPTION
Any messages that sent with a null or empty `text` field no longer throws the `message is not a valid Message instance` error. Instead if `text` is null it will fall back to an empty string.