### PR TITLE
Bump moment version because of ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "addressparser": "^0.3.2",
     "mimelib": "0.2.14",
-    "moment": "2.11.2",
+    "moment": "2.15.2",
     "starttls": "1.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Hi,
emailjs is being [reported as vulnerable](https://snyk.io/test/npm/emailjs), because of its dependency on moment@2.11.2.

This PR upgrades moment from 2.11.2 to 2.15.2, removing the [ReDoS vulnerability](https://snyk.io/vuln/npm:moment:20161019) in moment<2.15.2