### PR TITLE
updating moment.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "addressparser": "^0.3.2",
     "mimelib": "0.2.14",
-    "moment": "2.15.2",
+    "moment": "2.19.3",
     "starttls": "1.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
NSP listed moment.js with versions previous to 2.19.3 as vulnerable to ReDoS. Please see these links for more info [NSP-advisories-532](https://nodesecurity.io/advisories/532). And issue in [moment js](https://github.com/moment/moment/issues/4163).  