### PR TITLE
use sync fs.close to handle errors

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -317,7 +317,7 @@ var MessageStream = function(message)
    {
       var chunk      = MIME64CHUNK*16;
       var buffer     = new Buffer(chunk);
-      var closed     = function(fd) { if(fs.close) { fs.close(fd); } };
+      var closed     = function(fd) { if(fs.closeSync) { fs.closeSync(fd); } };
       var opened     = function(err, fd)
       {
          if(!err)


### PR DESCRIPTION
If this is the Node.js fs module as it seems like, this is a long time deprecated behavior. Instead, switch to the sync version to make sure errors get handled. This is otherwise going to throw from Node.js 10.x on. See https://github.com/nodejs/node/pull/18668.