### PR TITLE
Allow references and in-reply-to header support

### DIFF
--- a/smtp/message.js
+++ b/smtp/message.js
@@ -86,6 +86,27 @@ var Message = function(headers)
       {
          this.header[header.toLowerCase()] = person2address(headers[header]);
       }
+      else if(header == 'references')
+      {
+         var references = '';
+         for(var i = 0; i < headers[header].length; i++)
+         {
+            if(references)
+            {
+               references += " <" + headers[header][i] + '>';
+            }
+            else
+            {
+               references += '<' + headers[header][i] + '>';
+           }
+         }
+
+         this.header.references = references;
+      }
+      else if(header == 'inReplyTo')
+      {
+         this.header["in-reply-to"] = '<' + headers[header] + '>';
+      }
       else
       {
          // allow any headers the user wants to set??


### PR DESCRIPTION
Added references and in-reply-to header support. For example:

```
	var message = {
		text: "Hi",
		from: "example@email.com",
		to: "me me@example.com",
		inReplyTo: "1234@example.com",
		references: ["1232@example.com","1233@example.com","1234@example.com"],
		subject: "References and/or in-reply-to support"
	};

```
This way the sended message should contain:
```
	In-Reply-To: <1234@example.com>
	References: <1232@example.com>, <1233@example.com>, <1234@example.com>

```