### PR TITLE
refactor for modern features, `new Buffer` deprecation & tooling update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,10 @@
 		"plugin:prettier/recommended"
 	],
 	"rules": {
+		"curly": [
+			"error",
+			"all"
+		],
 		"linebreak-style": [
 			"error",
 			"unix"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,35 @@
+{
+	"env": {
+		"es6": true,
+		"mocha": true,
+		"node": true
+	},
+	"plugins": [
+		"mocha"
+	],
+	"extends": [
+		"eslint:recommended",
+		"plugin:prettier/recommended"
+	],
+	"rules": {
+		"linebreak-style": [
+			"error",
+			"unix"
+		],
+		"no-case-declarations": "off",
+		"no-console": "off",
+		"no-unused-vars": [
+			"error",
+			{
+				"vars": "all",
+				"args": "none",
+				"ignoreRestSiblings": true
+			}
+		],
+    "mocha/handle-done-callback": "error",
+    "mocha/no-exclusive-tests": "error",
+    "mocha/no-global-tests": "error",
+    "mocha/no-mocha-arrows": "error",
+    "mocha/no-skipped-tests": "error"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.swo
 *~
 
+yarn.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode/
 /node_modules/
 /test/config.js
 /npm-debug.log

--- a/email.js
+++ b/email.js
@@ -1,4 +1,4 @@
 exports.server = require('./smtp/client');
 exports.message = require('./smtp/message');
 exports.SMTP = require('./smtp/smtp');
-exports.error= require('./smtp/error');
+exports.error = require('./smtp/error');

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "moment": "2.20.1",
     "starttls": "1.0.1"
   },
-  "optionalDependencies": {
-    "bufferjs": "1.1.0"
-  },
   "devDependencies": {
     "chai": "1.1.0",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
     "bufferjs": "1.1.0"
   },
   "devDependencies": {
-    "mocha": "5.0.0",
     "chai": "1.1.0",
-    "smtp-server": "^3.4.1",
     "mailparser": "2.2.0",
-    "iconv": "2.2.1"
+    "mocha": "5.0.0",
+    "smtp-server": "^3.4.1"
   },
   "engine": [
     "node >= 6"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,13 @@
   },
   "devDependencies": {
     "chai": "1.1.0",
+    "eslint": "^4.19.1",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "mailparser": "2.2.0",
     "mocha": "5.0.0",
+    "prettier": "^1.12.1",
     "smtp-server": "^3.4.1"
   },
   "engine": [
@@ -35,5 +40,10 @@
   "scripts": {
     "test": "mocha -R spec"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "useTabs": true
+  }
 }

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -1,186 +1,185 @@
 const smtp = require('./smtp');
-const smtpError = require('./error');
 const message = require('./message');
 const addressparser = require('addressparser');
 
 class Client {
-  constructor(server) {
-    this.smtp = new smtp.SMTP(server);
-    //this.smtp.debug(1);
+	constructor(server) {
+		this.smtp = new smtp.SMTP(server);
+		//this.smtp.debug(1);
 
-    this.queue = [];
-    this.timer = null;
-    this.sending = false;
-    this.ready = false;
+		this.queue = [];
+		this.timer = null;
+		this.sending = false;
+		this.ready = false;
 	}
 
-  _poll() {
-    clearTimeout(this.timer);
+	_poll() {
+		clearTimeout(this.timer);
 
-    if (this.queue.length) {
-      if (this.smtp.state() == smtp.state.NOTCONNECTED) {
+		if (this.queue.length) {
+			if (this.smtp.state() == smtp.state.NOTCONNECTED) {
 				this._connect(this.queue[0]);
 			} else if (
-        this.smtp.state() == smtp.state.CONNECTED &&
-        !this.sending &&
-        this.ready
-      ) {
-        this._sendmail(this.queue.shift());
+				this.smtp.state() == smtp.state.CONNECTED &&
+				!this.sending &&
+				this.ready
+			) {
+				this._sendmail(this.queue.shift());
 			}
-    }
-    // wait around 1 seconds in case something does come in, otherwise close out SMTP connection if still open
-    else if (this.smtp.state() == smtp.state.CONNECTED)
-      this.timer = setTimeout(() => this.smtp.quit(), 1000);
-  }
+		}
+		// wait around 1 seconds in case something does come in, otherwise close out SMTP connection if still open
+		else if (this.smtp.state() == smtp.state.CONNECTED)
+			this.timer = setTimeout(() => this.smtp.quit(), 1000);
+	}
 
-  _connect(stack) {
-    const connect = err => {
-      if (!err) {
-        const begin = err => {
-          if (!err) {
-            this.ready = true;
-            this._poll();
-          } else {
-            stack.callback(err, stack.message);
+	_connect(stack) {
+		const connect = err => {
+			if (!err) {
+				const begin = err => {
+					if (!err) {
+						this.ready = true;
+						this._poll();
+					} else {
+						stack.callback(err, stack.message);
 
-            // clear out the queue so all callbacks can be called with the same error message
-            this.queue.shift();
-            this._poll();
-          }
-        };
+						// clear out the queue so all callbacks can be called with the same error message
+						this.queue.shift();
+						this._poll();
+					}
+				};
 
-        if (!this.smtp.authorized()) this.smtp.login(begin);
-        else this.smtp.ehlo_or_helo_if_needed(begin);
-      } else {
-        stack.callback(err, stack.message);
+				if (!this.smtp.authorized()) this.smtp.login(begin);
+				else this.smtp.ehlo_or_helo_if_needed(begin);
+			} else {
+				stack.callback(err, stack.message);
 
-        // clear out the queue so all callbacks can be called with the same error message
-        this.queue.shift();
-        this._poll();
-      }
-    };
+				// clear out the queue so all callbacks can be called with the same error message
+				this.queue.shift();
+				this._poll();
+			}
+		};
 
-    this.ready = false;
-    this.smtp.connect(connect);
-  }
+		this.ready = false;
+		this.smtp.connect(connect);
+	}
 
-  send(msg, callback) {
-    if (
-      !(msg instanceof message.Message) &&
-      msg.from &&
-      (msg.to || msg.cc || msg.bcc) &&
-      (msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
-    )
-      msg = message.create(msg);
+	send(msg, callback) {
+		if (
+			!(msg instanceof message.Message) &&
+			msg.from &&
+			(msg.to || msg.cc || msg.bcc) &&
+			(msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
+		)
+			msg = message.create(msg);
 
-    if (msg instanceof message.Message) {
-      msg.valid((valid, why) => {
-        if (valid) {
-          const stack = {
-            message: msg,
-            to: addressparser(msg.header.to),
-            from: addressparser(msg.header.from)[0].address,
-            callback: (callback || function() {}).bind(this),
-          };
+		if (msg instanceof message.Message) {
+			msg.valid((valid, why) => {
+				if (valid) {
+					const stack = {
+						message: msg,
+						to: addressparser(msg.header.to),
+						from: addressparser(msg.header.from)[0].address,
+						callback: (callback || function() {}).bind(this),
+					};
 
-          if (msg.header.cc)
-            stack.to = stack.to.concat(addressparser(msg.header.cc));
+					if (msg.header.cc)
+						stack.to = stack.to.concat(addressparser(msg.header.cc));
 
-          if (msg.header.bcc)
-            stack.to = stack.to.concat(addressparser(msg.header.bcc));
+					if (msg.header.bcc)
+						stack.to = stack.to.concat(addressparser(msg.header.bcc));
 
-          if (
-            msg.header['return-path'] &&
-            addressparser(msg.header['return-path']).length
-          )
-            stack.returnPath = addressparser(
-              msg.header['return-path']
-            )[0].address;
+					if (
+						msg.header['return-path'] &&
+						addressparser(msg.header['return-path']).length
+					)
+						stack.returnPath = addressparser(
+							msg.header['return-path']
+						)[0].address;
 
-          this.queue.push(stack);
-          this._poll();
-        } else {
+					this.queue.push(stack);
+					this._poll();
+				} else {
 					callback(new Error(why), msg);
 				}
-      });
-    } else {
+			});
+		} else {
 			callback(new Error('message is not a valid Message instance'), msg);
+		}
+	}
+
+	_containsInlinedHtml(attachment) {
+		if (Array.isArray(attachment)) {
+			return attachment.some(() => {
+				return att => {
+					return this._isAttachmentInlinedHtml(att);
+				};
+			});
+		} else {
+			return this._isAttachmentInlinedHtml(attachment);
+		}
+	}
+
+	_isAttachmentInlinedHtml(attachment) {
+		return (
+			attachment &&
+			(attachment.data || attachment.path) &&
+			attachment.alternative === true
+		);
+	}
+
+	_sendsmtp(stack, next) {
+		return err => {
+			if (!err && next) {
+				next.apply(this, [stack]);
+			} else {
+				// if we snag on SMTP commands, call done, passing the error
+				// but first reset SMTP state so queue can continue polling
+				this.smtp.rset(() => this._senddone(err, stack));
+			}
 		};
-  }
-
-  _containsInlinedHtml(attachment) {
-    if (Array.isArray(attachment)) {
-      return attachment.some(() => {
-        return att => {
-          return this._isAttachmentInlinedHtml(att);
-        };
-      });
-    } else {
-      return this._isAttachmentInlinedHtml(attachment);
-    }
-  }
-
-  _isAttachmentInlinedHtml(attachment) {
-    return (
-      attachment &&
-      (attachment.data || attachment.path) &&
-      attachment.alternative === true
-    );
-  }
-
-  _sendsmtp(stack, next) {
-    return err => {
-      if (!err && next) {
-        next.apply(this, [stack]);
-      } else {
-        // if we snag on SMTP commands, call done, passing the error
-        // but first reset SMTP state so queue can continue polling
-        this.smtp.rset(() => this._senddone(err, stack));
-      }
-    };
 	}
 
 	_sendmail(stack) {
-    const from = stack.returnPath || stack.from;
-    this.sending = true;
-    this.smtp.mail(this._sendsmtp(stack, this._sendrcpt), '<' + from + '>');
+		const from = stack.returnPath || stack.from;
+		this.sending = true;
+		this.smtp.mail(this._sendsmtp(stack, this._sendrcpt), '<' + from + '>');
 	}
 
 	_sendrcpt(stack) {
-    const to = stack.to.shift().address;
-    this.smtp.rcpt(
-      this._sendsmtp(stack, stack.to.length ? this._sendrcpt : this._senddata),
-      '<' + to + '>'
-    );
+		const to = stack.to.shift().address;
+		this.smtp.rcpt(
+			this._sendsmtp(stack, stack.to.length ? this._sendrcpt : this._senddata),
+			'<' + to + '>'
+		);
 	}
 
 	_senddata(stack) {
-    this.smtp.data(this._sendsmtp(stack, this._sendmessage));
-  }
+		this.smtp.data(this._sendsmtp(stack, this._sendmessage));
+	}
 
-  _sendmessage(stack) {
-    const stream = stack.message.stream();
+	_sendmessage(stack) {
+		const stream = stack.message.stream();
 
-    stream.on('data', (data) =>  this.smtp.message(data));
-    stream.on('end', () => {
-      this.smtp.data_end(
-        this._sendsmtp(stack, () => this._senddone(null, stack))
-      );
-    });
+		stream.on('data', data => this.smtp.message(data));
+		stream.on('end', () => {
+			this.smtp.data_end(
+				this._sendsmtp(stack, () => this._senddone(null, stack))
+			);
+		});
 
 		// there is no way to cancel a message while in the DATA portion,
 		// so we have to close the socket to prevent a bad email from going out
-    stream.on('error', (err) => {
-      this.smtp.close();
-      this._senddone(err, stack);
-    });
+		stream.on('error', err => {
+			this.smtp.close();
+			this._senddone(err, stack);
+		});
 	}
 
 	_senddone(err, stack) {
-    this.sending = false;
-    stack.callback(err, stack.message);
-    this._poll();
-  }
+		this.sending = false;
+		stack.callback(err, stack.message);
+		this._poll();
+	}
 }
 
 exports.Client = Client;

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -27,9 +27,11 @@ class Client {
 				this._sendmail(this.queue.shift());
 			}
 		}
-		// wait around 1 seconds in case something does come in, otherwise close out SMTP connection if still open
-		else if (this.smtp.state() == smtp.state.CONNECTED)
+		// wait around 1 seconds in case something does come in,
+		// otherwise close out SMTP connection if still open
+		else if (this.smtp.state() == smtp.state.CONNECTED) {
 			this.timer = setTimeout(() => this.smtp.quit(), 1000);
+		}
 	}
 
 	_connect(stack) {
@@ -48,8 +50,11 @@ class Client {
 					}
 				};
 
-				if (!this.smtp.authorized()) this.smtp.login(begin);
-				else this.smtp.ehlo_or_helo_if_needed(begin);
+				if (!this.smtp.authorized()) {
+					this.smtp.login(begin);
+				} else {
+					this.smtp.ehlo_or_helo_if_needed(begin);
+				}
 			} else {
 				stack.callback(err, stack.message);
 
@@ -69,8 +74,9 @@ class Client {
 			msg.from &&
 			(msg.to || msg.cc || msg.bcc) &&
 			(msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
-		)
+		) {
 			msg = message.create(msg);
+		}
 
 		if (msg instanceof message.Message) {
 			msg.valid((valid, why) => {
@@ -82,19 +88,22 @@ class Client {
 						callback: (callback || function() {}).bind(this),
 					};
 
-					if (msg.header.cc)
+					if (msg.header.cc) {
 						stack.to = stack.to.concat(addressparser(msg.header.cc));
+					}
 
-					if (msg.header.bcc)
+					if (msg.header.bcc) {
 						stack.to = stack.to.concat(addressparser(msg.header.bcc));
+					}
 
 					if (
 						msg.header['return-path'] &&
 						addressparser(msg.header['return-path']).length
-					)
+					) {
 						stack.returnPath = addressparser(
 							msg.header['return-path']
 						)[0].address;
+					}
 
 					this.queue.push(stack);
 					this._poll();

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -1,209 +1,187 @@
-var smtp       = require('./smtp');
-var smtpError    = require('./error');
-var message      = require('./message');
-var addressparser= require('addressparser');
+const smtp = require('./smtp');
+const smtpError = require('./error');
+const message = require('./message');
+const addressparser = require('addressparser');
 
-var Client = function(server)
-{
-   this.smtp         = new smtp.SMTP(server);
-   //this.smtp.debug(1);
+class Client {
+  constructor(server) {
+    this.smtp = new smtp.SMTP(server);
+    //this.smtp.debug(1);
 
-   this.queue        = [];
-   this.timer        = null;
-   this.sending      = false;
-   this.ready        = false;
-};
+    this.queue = [];
+    this.timer = null;
+    this.sending = false;
+    this.ready = false;
+	}
 
-Client.prototype = 
-{
-   _poll: function()
-   {
-      var self = this;
+  _poll() {
+    clearTimeout(this.timer);
 
-      clearTimeout(self.timer);
+    if (this.queue.length) {
+      if (this.smtp.state() == smtp.state.NOTCONNECTED) {
+				this._connect(this.queue[0]);
+			} else if (
+        this.smtp.state() == smtp.state.CONNECTED &&
+        !this.sending &&
+        this.ready
+      ) {
+        this._sendmail(this.queue.shift());
+			}
+    }
+    // wait around 1 seconds in case something does come in, otherwise close out SMTP connection if still open
+    else if (this.smtp.state() == smtp.state.CONNECTED)
+      this.timer = setTimeout(() => this.smtp.quit(), 1000);
+  }
 
-      if(self.queue.length)
-      {
-         if(self.smtp.state() == smtp.state.NOTCONNECTED)
-            self._connect(self.queue[0]);
-
-         else if(self.smtp.state() == smtp.state.CONNECTED && !self.sending && self.ready)
-            self._sendmail(self.queue.shift());
-      }
-      // wait around 1 seconds in case something does come in, otherwise close out SMTP connection if still open
-      else if(self.smtp.state() == smtp.state.CONNECTED)
-         self.timer = setTimeout(function() { self.smtp.quit(); }, 1000);
-   },
-
-   _connect: function(stack)
-   {
-      var self = this,
-
-      connect = function(err)
-      {
-         if(!err)
-         {
-            var begin = function(err)
-            {
-               if(!err)
-               {
-                  self.ready = true;
-                  self._poll();
-               }
-               else {
-                  stack.callback(err, stack.message);
-
-                  // clear out the queue so all callbacks can be called with the same error message
-                  self.queue.shift();
-                  self._poll();
-               }
-            };
-
-            if(!self.smtp.authorized())
-               self.smtp.login(begin);
-
-            else
-               self.smtp.ehlo_or_helo_if_needed(begin);
-         }
-         else {
+  _connect(stack) {
+    const connect = err => {
+      if (!err) {
+        const begin = err => {
+          if (!err) {
+            this.ready = true;
+            this._poll();
+          } else {
             stack.callback(err, stack.message);
 
             // clear out the queue so all callbacks can be called with the same error message
-            self.queue.shift();
-            self._poll();
-         }
-      };
+            this.queue.shift();
+            this._poll();
+          }
+        };
 
-      self.ready = false;
-      self.smtp.connect(connect);
-   },
+        if (!this.smtp.authorized()) this.smtp.login(begin);
+        else this.smtp.ehlo_or_helo_if_needed(begin);
+      } else {
+        stack.callback(err, stack.message);
 
-   send: function(msg, callback)
-   {
-      var self = this;
-
-      if(!(msg instanceof message.Message) 
-          && msg.from 
-          && (msg.to || msg.cc || msg.bcc)
-          && (msg.text !== undefined || this._containsInlinedHtml(msg.attachment)))
-         msg = message.create(msg);
-
-      if(msg instanceof message.Message)
-      {
-         msg.valid(function(valid, why)
-         {
-            if(valid)
-            {
-               var stack = 
-               {
-                  message:    msg,
-                  to:         addressparser(msg.header.to),
-                  from:       addressparser(msg.header.from)[0].address,
-                  callback:   callback || function() {}
-               };
-
-               if(msg.header.cc)
-                  stack.to = stack.to.concat(addressparser(msg.header.cc));
-
-               if(msg.header.bcc)
-                  stack.to = stack.to.concat(addressparser(msg.header.bcc));
-
-               if(msg.header['return-path'] && addressparser(msg.header['return-path']).length)
-                 stack.returnPath = addressparser(msg.header['return-path'])[0].address;
-
-               self.queue.push(stack);
-               self._poll();
-            }
-            else
-               callback(new Error(why), msg);
-         });
+        // clear out the queue so all callbacks can be called with the same error message
+        this.queue.shift();
+        this._poll();
       }
-      else
-         callback(new Error("message is not a valid Message instance"), msg);
-   },
+    };
 
-   _containsInlinedHtml: function(attachment) {
-	   if (Array.isArray(attachment)) {
-		   return attachment.some((function(ctx) {
-			   return function(att) {
-				   return ctx._isAttachmentInlinedHtml(att);
-			   };
-		   })(this));
-	   } else {
-		   return this._isAttachmentInlinedHtml(attachment);
-	   }   
-	},
+    this.ready = false;
+    this.smtp.connect(connect);
+  }
 
-   _isAttachmentInlinedHtml: function(attachment) {
-	   return attachment && 
-		  (attachment.data || attachment.path) && 
-		   attachment.alternative === true;
-   },
+  send(msg, callback) {
+    if (
+      !(msg instanceof message.Message) &&
+      msg.from &&
+      (msg.to || msg.cc || msg.bcc) &&
+      (msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
+    )
+      msg = message.create(msg);
 
-   _sendsmtp: function(stack, next)
-   {
-      var self   = this;
-      var check= function(err)
-      {
-         if(!err && next)
-         {
-            next.apply(self, [stack]);
-         }
-         else
-         {
-            // if we snag on SMTP commands, call done, passing the error
-            // but first reset SMTP state so queue can continue polling
-            self.smtp.rset(function() { self._senddone(err, stack); });
-         }
-      };
+    if (msg instanceof message.Message) {
+      msg.valid((valid, why) => {
+        if (valid) {
+          const stack = {
+            message: msg,
+            to: addressparser(msg.header.to),
+            from: addressparser(msg.header.from)[0].address,
+            callback: (callback || function() {}).bind(this),
+          };
 
-      return check;
-   },
+          if (msg.header.cc)
+            stack.to = stack.to.concat(addressparser(msg.header.cc));
 
-   _sendmail: function(stack)
-   {
-      var self = this;
-      var from = stack.returnPath || stack.from;
-      self.sending = true;
-      self.smtp.mail(self._sendsmtp(stack, self._sendrcpt), '<' + from + '>');
-   },
+          if (msg.header.bcc)
+            stack.to = stack.to.concat(addressparser(msg.header.bcc));
 
-   _sendrcpt: function(stack)
-   {
-      var self = this, to = stack.to.shift().address;
-      self.smtp.rcpt(self._sendsmtp(stack, stack.to.length ? self._sendrcpt : self._senddata), '<'+ to +'>');
-   },
+          if (
+            msg.header['return-path'] &&
+            addressparser(msg.header['return-path']).length
+          )
+            stack.returnPath = addressparser(
+              msg.header['return-path']
+            )[0].address;
 
-   _senddata: function(stack)
-   {
-      var self = this;
-      self.smtp.data(self._sendsmtp(stack, self._sendmessage));
-   },
+          this.queue.push(stack);
+          this._poll();
+        } else {
+					callback(new Error(why), msg);
+				}
+      });
+    } else {
+			callback(new Error('message is not a valid Message instance'), msg);
+		};
+  }
 
-   _sendmessage: function(stack)
-   {
-      var self = this, stream = stack.message.stream();
+  _containsInlinedHtml(attachment) {
+    if (Array.isArray(attachment)) {
+      return attachment.some(() => {
+        return att => {
+          return this._isAttachmentInlinedHtml(att);
+        };
+      });
+    } else {
+      return this._isAttachmentInlinedHtml(attachment);
+    }
+  }
 
-      stream.on('data', function(data) { self.smtp.message(data); });
-      stream.on('end', function() { self.smtp.data_end(self._sendsmtp(stack, function() { self._senddone(null, stack) })); });
+  _isAttachmentInlinedHtml(attachment) {
+    return (
+      attachment &&
+      (attachment.data || attachment.path) &&
+      attachment.alternative === true
+    );
+  }
 
-      // there is no way to cancel a message while in the DATA portion, so we have to close the socket to prevent
-      // a bad email from going out
-      stream.on('error', function(err) { self.smtp.close(); self._senddone(err, stack); });
-   },
+  _sendsmtp(stack, next) {
+    return err => {
+      if (!err && next) {
+        next.apply(this, [stack]);
+      } else {
+        // if we snag on SMTP commands, call done, passing the error
+        // but first reset SMTP state so queue can continue polling
+        this.smtp.rset(() => this._senddone(err, stack));
+      }
+    };
+	}
 
-   _senddone: function(err, stack)
-   {
-      var self = this;
-      self.sending = false;
-      stack.callback(err, stack.message);
-      self._poll();
-   }
-};
+	_sendmail(stack) {
+    const from = stack.returnPath || stack.from;
+    this.sending = true;
+    this.smtp.mail(this._sendsmtp(stack, this._sendrcpt), '<' + from + '>');
+	}
+
+	_sendrcpt(stack) {
+    const to = stack.to.shift().address;
+    this.smtp.rcpt(
+      this._sendsmtp(stack, stack.to.length ? this._sendrcpt : this._senddata),
+      '<' + to + '>'
+    );
+	}
+
+	_senddata(stack) {
+    this.smtp.data(this._sendsmtp(stack, this._sendmessage));
+  }
+
+  _sendmessage(stack) {
+    const stream = stack.message.stream();
+
+    stream.on('data', (data) =>  this.smtp.message(data));
+    stream.on('end', () => {
+      this.smtp.data_end(
+        this._sendsmtp(stack, () => this._senddone(null, stack))
+      );
+    });
+
+		// there is no way to cancel a message while in the DATA portion,
+		// so we have to close the socket to prevent a bad email from going out
+    stream.on('error', (err) => {
+      this.smtp.close();
+      this._senddone(err, stack);
+    });
+	}
+
+	_senddone(err, stack) {
+    this.sending = false;
+    stack.callback(err, stack.message);
+    this._poll();
+  }
+}
 
 exports.Client = Client;
-
-exports.connect = function(server)
-{
-   return new Client(server);
-};
+exports.connect = server => new Client(server);

--- a/smtp/error.js
+++ b/smtp/error.js
@@ -1,16 +1,16 @@
 module.exports = function(message, code, error, smtp) {
-  const err = new Error(
-    error && error.message ? `${message} (${error.message})` : message
-  );
+	const err = new Error(
+		error && error.message ? `${message} (${error.message})` : message
+	);
 
 	err.code = code;
-  err.smtp = smtp;
+	err.smtp = smtp;
 
 	if (error) {
 		err.previous = error;
 	}
 
-  return err;
+	return err;
 };
 
 module.exports.COULDNOTCONNECT = 1;

--- a/smtp/error.js
+++ b/smtp/error.js
@@ -1,14 +1,19 @@
 module.exports = function(message, code, error, smtp) {
-  var err = new Error((error && error.message) ? message + ' (' + error.message + ')' : message);
-  err.code = code;
-  if(error)
-    err.previous = error;
+  const err = new Error(
+    error && error.message ? `${message} (${error.message})` : message
+  );
+
+	err.code = code;
   err.smtp = smtp;
+
+	if (error) {
+		err.previous = error;
+	}
 
   return err;
 };
 
-module.exports.COULDNOTCONNECT =	1;
+module.exports.COULDNOTCONNECT = 1;
 module.exports.BADRESPONSE = 2;
 module.exports.AUTHFAILED = 3;
 module.exports.TIMEDOUT = 4;

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -12,11 +12,6 @@ const BUFFERSIZE = MIMECHUNK * 24 * 7; // size of the message stream buffer
 
 let counter = 0;
 
-// support for nodejs without Buffer.concat native function
-if (!Buffer.concat) {
-	require('bufferjs/concat');
-}
-
 function generate_boundary() {
 	let text = '';
 	const possible =

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -140,11 +140,13 @@ class Message {
 			this.attachments.forEach(attachment => {
 				if (attachment.path) {
 					// migrating path->fs for existsSync)
-					if (!(fs.existsSync || path.existsSync)(attachment.path))
+					if (!(fs.existsSync || path.existsSync)(attachment.path)) {
 						failed.push(`${attachment.path} does not exist`);
+					}
 				} else if (attachment.stream) {
-					if (!attachment.stream.readable)
+					if (!attachment.stream.readable) {
 						failed.push('attachment stream is not readable');
+					}
 				} else if (!attachment.data) {
 					failed.push('attachment has no data associated with it');
 				}
@@ -363,7 +365,9 @@ class MessageStream extends Stream {
 				output(data.substring(MIMECHUNK * loop, MIMECHUNK * (loop + 1)) + CRLF);
 				loop++;
 			}
-			if (callback) callback();
+			if (callback) {
+				callback();
+			}
 		};
 
 		const output_text = message => {
@@ -455,7 +459,9 @@ class MessageStream extends Stream {
 			if (bytes + this.bufferIndex < this.buffer.length) {
 				this.buffer.write(data, this.bufferIndex);
 				this.bufferIndex += bytes;
-				if (callback) callback.apply(null, args);
+				if (callback) {
+					callback.apply(null, args);
+				}
 			}
 			// we can't buffer the data, so ship it out!
 			else if (bytes > this.buffer.length) {

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -59,7 +59,7 @@ class Message {
 		};
 
 		this.content = 'text/plain; charset=utf-8';
-		for (let header in headers) {
+		for (const header in headers) {
 			// allow user to override default content-type to override charset or send a single non-text message
 			if (/^content-type$/i.test(header)) {
 				this.content = headers[header];
@@ -224,12 +224,12 @@ class MessageStream extends Stream {
 					: `attachment; filename="${mimeWordEncode(attachment.name)}"`,
 			};
 
-			for (let header in attachment.headers || {}) {
+			for (const header in attachment.headers || {}) {
 				// allow sender to override default headers
 				headers[header.toLowerCase()] = attachment.headers[header];
 			}
 
-			for (let header in headers) {
+			for (const header in headers) {
 				data = data.concat([
 					fix_header_name_case(header),
 					': ',
@@ -429,7 +429,7 @@ class MessageStream extends Stream {
 		const output_header = () => {
 			let data = [];
 
-			for (let header in this.message.header) {
+			for (const header in this.message.header) {
 				// do not output BCC in the headers (regex) nor custom Object.prototype functions...
 				if (
 					!/bcc/i.test(header) &&

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -7,7 +7,6 @@ const mimeWordEncode = require('emailjs-mime-codec').mimeWordEncode;
 const addressparser = require('addressparser');
 const CRLF = '\r\n';
 const MIMECHUNK = 76; // MIME standard wants 76 char chunks when sending out.
-const BASE64CHUNK = 24; // BASE64 bits needed before padding is used
 const MIME64CHUNK = MIMECHUNK * 6; // meets both base64 and mime divisibility
 const BUFFERSIZE = MIMECHUNK * 24 * 7; // size of the message stream buffer
 
@@ -15,497 +14,528 @@ let counter = 0;
 
 // support for nodejs without Buffer.concat native function
 if (!Buffer.concat) {
-  require('bufferjs/concat');
+	require('bufferjs/concat');
 }
 
 function generate_boundary() {
-  let text = '';
-  const possible = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'()+_,-./:=?`;
+	let text = '';
+	const possible =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'()+_,-./:=?";
 
-  for (let i = 0; i < 69; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
+	for (let i = 0; i < 69; i++) {
+		text += possible.charAt(Math.floor(Math.random() * possible.length));
 	}
 
-  return text;
+	return text;
 }
 
 function person2address(l) {
-  return addressparser(l)
-    .map(({ name, address }) => {
-      return name
-        ? `${mimeWordEncode(name).replace(/,/g, '=2C')} <${address}>`
-        : address;
-    })
-    .join(', ');
+	return addressparser(l)
+		.map(({ name, address }) => {
+			return name
+				? `${mimeWordEncode(name).replace(/,/g, '=2C')} <${address}>`
+				: address;
+		})
+		.join(', ');
 }
 
 function fix_header_name_case(header_name) {
-  return header_name
-    .toLowerCase()
-    .replace(/^(.)|-(.)/g, match => match.toUpperCase());
+	return header_name
+		.toLowerCase()
+		.replace(/^(.)|-(.)/g, match => match.toUpperCase());
 }
 
 class Message {
-  constructor(headers) {
-    this.attachments = [];
-    this.alternative = null;
-    this.header = {
-      'message-id': `<${new Date().getTime()}.${counter++}.${process.pid}@${os.hostname()}>`,
-      date: moment()
-        .locale('en')
-        .format('ddd, DD MMM YYYY HH:mm:ss ZZ')
+	constructor(headers) {
+		this.attachments = [];
+		this.alternative = null;
+		this.header = {
+			'message-id': `<${new Date().getTime()}.${counter++}.${
+				process.pid
+			}@${os.hostname()}>`,
+			date: moment()
+				.locale('en')
+				.format('ddd, DD MMM YYYY HH:mm:ss ZZ'),
 		};
 
-    this.content = 'text/plain; charset=utf-8';
-    for (let header in headers) {
-      // allow user to override default content-type to override charset or send a single non-text message
-      if (/^content-type$/i.test(header)) {
-        this.content = headers[header];
-      } else if (header === 'text') {
-        this.text = headers[header];
-      } else if (header === 'attachment' && typeof headers[header] === 'object') {
-        if (Array.isArray(headers[header])) {
-          for (let i = 0, l = headers[header].length; i < l; i++) {
-            this.attach(headers[header][i]);
-          }
-        } else {
-          this.attach(headers[header]);
-        }
-      } else if (header === 'subject') {
-        this.header.subject = mimeWordEncode(headers.subject);
-      } else if (/^(cc|bcc|to|from)/i.test(header)) {
-        this.header[header.toLowerCase()] = person2address(headers[header]);
-      } else {
-        // allow any headers the user wants to set??
-        // if(/cc|bcc|to|from|reply-to|sender|subject|date|message-id/i.test(header))
-        this.header[header.toLowerCase()] = headers[header];
-      }
+		this.content = 'text/plain; charset=utf-8';
+		for (let header in headers) {
+			// allow user to override default content-type to override charset or send a single non-text message
+			if (/^content-type$/i.test(header)) {
+				this.content = headers[header];
+			} else if (header === 'text') {
+				this.text = headers[header];
+			} else if (
+				header === 'attachment' &&
+				typeof headers[header] === 'object'
+			) {
+				if (Array.isArray(headers[header])) {
+					for (let i = 0, l = headers[header].length; i < l; i++) {
+						this.attach(headers[header][i]);
+					}
+				} else {
+					this.attach(headers[header]);
+				}
+			} else if (header === 'subject') {
+				this.header.subject = mimeWordEncode(headers.subject);
+			} else if (/^(cc|bcc|to|from)/i.test(header)) {
+				this.header[header.toLowerCase()] = person2address(headers[header]);
+			} else {
+				// allow any headers the user wants to set??
+				// if(/cc|bcc|to|from|reply-to|sender|subject|date|message-id/i.test(header))
+				this.header[header.toLowerCase()] = headers[header];
+			}
 		}
 	}
 
 	attach(options) {
-    /*
+		/*
          legacy support, will remove eventually...
          arguments -> (path, type, name, headers)
       */
-    if (arguments.length > 1) {
-      options = { path: options, type: arguments[1], name: arguments[2] };
+		if (arguments.length > 1) {
+			options = { path: options, type: arguments[1], name: arguments[2] };
 		}
 
-    // sender can specify an attachment as an alternative
-    if (options.alternative) {
-      this.alternative = options;
-      this.alternative.charset = options.charset || 'utf-8';
-      this.alternative.type = options.type || 'text/html';
-      this.alternative.inline = true;
-    } else {
+		// sender can specify an attachment as an alternative
+		if (options.alternative) {
+			this.alternative = options;
+			this.alternative.charset = options.charset || 'utf-8';
+			this.alternative.type = options.type || 'text/html';
+			this.alternative.inline = true;
+		} else {
 			this.attachments.push(options);
 		}
 
-    return this;
-  }
+		return this;
+	}
 
-  /*
+	/*
       legacy support, will remove eventually...
       should use Message.attach() instead
    */
-  attach_alternative(html, charset) {
-    this.alternative = {
-      data: html,
-      charset: charset || 'utf-8',
-      type: 'text/html',
-      inline: true
-    };
+	attach_alternative(html, charset) {
+		this.alternative = {
+			data: html,
+			charset: charset || 'utf-8',
+			type: 'text/html',
+			inline: true,
+		};
 
-    return this;
-  }
+		return this;
+	}
 
-  valid(callback) {
-    if (!this.header.from) {
-      callback(false, 'message does not have a valid sender');
+	valid(callback) {
+		if (!this.header.from) {
+			callback(false, 'message does not have a valid sender');
 		}
 
-    if (!(this.header.to || this.header.cc || this.header.bcc)) {
-      callback(false, 'message does not have a valid recipient');
-    } else if (this.attachments.length === 0) {
-      callback(true);
-    } else {
-      const failed = [];
+		if (!(this.header.to || this.header.cc || this.header.bcc)) {
+			callback(false, 'message does not have a valid recipient');
+		} else if (this.attachments.length === 0) {
+			callback(true);
+		} else {
+			const failed = [];
 
-      this.attachments.forEach((attachment, index) => {
-        if (attachment.path) {
-          // migrating path->fs for existsSync)
-          if (!(fs.existsSync || path.existsSync)(attachment.path))
-            failed.push(`${attachment.path} does not exist`);
-        } else if (attachment.stream) {
-          if (!attachment.stream.readable)
-            failed.push('attachment stream is not readable');
-        } else if (!attachment.data) {
-          failed.push('attachment has no data associated with it');
-        }
-      });
+			this.attachments.forEach(attachment => {
+				if (attachment.path) {
+					// migrating path->fs for existsSync)
+					if (!(fs.existsSync || path.existsSync)(attachment.path))
+						failed.push(`${attachment.path} does not exist`);
+				} else if (attachment.stream) {
+					if (!attachment.stream.readable)
+						failed.push('attachment stream is not readable');
+				} else if (!attachment.data) {
+					failed.push('attachment has no data associated with it');
+				}
+			});
 
-      callback(failed.length === 0, failed.join(', '));
-    }
-  }
+			callback(failed.length === 0, failed.join(', '));
+		}
+	}
 
-  stream() {
-    return new MessageStream(this);
-  }
+	stream() {
+		return new MessageStream(this);
+	}
 
-  read(callback) {
-    let buffer = '';
-    const str = this.stream();
-    str.on('data', (data) => buffer += data);
-    str.on('end', (err) => callback(err, buffer));
-    str.on('error', (err) => callback(err, buffer));
-  }
+	read(callback) {
+		let buffer = '';
+		const str = this.stream();
+		str.on('data', data => (buffer += data));
+		str.on('end', err => callback(err, buffer));
+		str.on('error', err => callback(err, buffer));
+	}
 }
 
 class MessageStream extends Stream {
-  constructor(message) {
+	constructor(message) {
 		super();
 
-    this.message = message;
-    this.readable = true;
-    this.paused = false;
-    this.buffer = Buffer.alloc(MIMECHUNK * 24 * 7);
-    this.bufferIndex = 0;
+		this.message = message;
+		this.readable = true;
+		this.paused = false;
+		this.buffer = Buffer.alloc(MIMECHUNK * 24 * 7);
+		this.bufferIndex = 0;
 
-    const output_mixed = () => {
-      const boundary = generate_boundary();
-      output(
-        `Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`
-      );
+		const output_mixed = () => {
+			const boundary = generate_boundary();
+			output(
+				`Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`
+			);
 
-      if (!this.message.alternative) {
-        output_text(this.message);
-        output_message(boundary, this.message.attachments, 0, close);
-      } else {
-        const cb = () => output_message(boundary, this.message.attachments, 0, close);
-        output_alternative(this.message, cb);
-      }
-    };
-
-    const output_message = (boundary, list, index, callback) => {
-      if (index < list.length) {
-        output(`--${boundary}${CRLF}`);
-        if (list[index].related) {
-          output_related(list[index], () =>
-            output_message(boundary, list, index + 1, callback)
-          );
-        } else {
-          output_attachment(list[index], () =>
-            output_message(boundary, list, index + 1, callback)
-          );
-        }
-      } else {
-        output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
-        callback();
-      }
-    };
-
-    const output_attachment_headers = attachment => {
-      let data = [];
-      const headers = {
-        'content-type':
-          attachment.type +
-          (attachment.charset ? `; charset=${attachment.charset}` : '') +
-          (attachment.method ? `; method=${attachment.method}` : ''),
-        'content-transfer-encoding': 'base64',
-        'content-disposition': attachment.inline
-          ? 'inline'
-          : `attachment; filename="${mimeWordEncode(attachment.name)}"`
-      };
-
-      for (let header in attachment.headers || {}) {
-        // allow sender to override default headers
-        headers[header.toLowerCase()] = attachment.headers[header];
-      }
-
-      for (let header in headers) {
-        data = data.concat([
-          fix_header_name_case(header),
-          ': ',
-          headers[header],
-          CRLF
-        ]);
-      }
-
-      output(data.concat([CRLF]).join(''));
-    };
-
-    const output_attachment = (attachment, callback) => {
-      const build = attachment.path
-        ? output_file
-        : attachment.stream
-          ? output_stream
-          : output_data;
-      output_attachment_headers(attachment);
-      build(attachment, callback);
+			if (!this.message.alternative) {
+				output_text(this.message);
+				output_message(boundary, this.message.attachments, 0, close);
+			} else {
+				const cb = () =>
+					output_message(boundary, this.message.attachments, 0, close);
+				output_alternative(this.message, cb);
+			}
 		};
 
-    const output_data = (attachment, callback) => {
-      output_base64(
-        attachment.encoded
-          ? attachment.data
-          : Buffer.from(attachment.data).toString('base64'),
-        callback
-      );
+		const output_message = (boundary, list, index, callback) => {
+			if (index < list.length) {
+				output(`--${boundary}${CRLF}`);
+				if (list[index].related) {
+					output_related(list[index], () =>
+						output_message(boundary, list, index + 1, callback)
+					);
+				} else {
+					output_attachment(list[index], () =>
+						output_message(boundary, list, index + 1, callback)
+					);
+				}
+			} else {
+				output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
+				callback();
+			}
 		};
 
-    const output_file = (attachment, next) => {
-      const chunk = MIME64CHUNK * 16;
-      const buffer = Buffer.alloc(chunk);
-      const closed = (fd) => {
-        if (fs.closeSync) {
-          fs.closeSync(fd);
-        }
+		const output_attachment_headers = attachment => {
+			let data = [];
+			const headers = {
+				'content-type':
+					attachment.type +
+					(attachment.charset ? `; charset=${attachment.charset}` : '') +
+					(attachment.method ? `; method=${attachment.method}` : ''),
+				'content-transfer-encoding': 'base64',
+				'content-disposition': attachment.inline
+					? 'inline'
+					: `attachment; filename="${mimeWordEncode(attachment.name)}"`,
 			};
 
-      const opened = (err, fd) => {
-        if (!err) {
-          const read = (err, bytes) => {
-            if (!err && this.readable) {
-              let encoding =
-                attachment && attachment.headers
-                  ? attachment.headers['content-transfer-encoding'] || 'base64'
-                  : 'base64';
-              if (encoding === 'ascii' || encoding === '7bit') {
-                encoding = 'ascii';
-              } else if (encoding === 'binary' || encoding === '8bit') {
-                encoding = 'binary';
-              } else {
-                encoding = 'base64';
-              }
-              // guaranteed to be encoded without padding unless it is our last read
-              output_base64(buffer.toString(encoding, 0, bytes), () => {
-                if (bytes == chunk) {
-                  // we read a full chunk, there might be more
-                  fs.read(fd, buffer, 0, chunk, null, read);
-                } // that was the last chunk, we are done reading the file
-                else {
-                  this.removeListener('error', closed);
-                  fs.close(fd, next);
-                }
-              });
-            } else {
-              this.emit('error', err || { message: 'message stream was interrupted somehow!' });
-            }
+			for (let header in attachment.headers || {}) {
+				// allow sender to override default headers
+				headers[header.toLowerCase()] = attachment.headers[header];
+			}
+
+			for (let header in headers) {
+				data = data.concat([
+					fix_header_name_case(header),
+					': ',
+					headers[header],
+					CRLF,
+				]);
+			}
+
+			output(data.concat([CRLF]).join(''));
+		};
+
+		const output_attachment = (attachment, callback) => {
+			const build = attachment.path
+				? output_file
+				: attachment.stream
+					? output_stream
+					: output_data;
+			output_attachment_headers(attachment);
+			build(attachment, callback);
+		};
+
+		const output_data = (attachment, callback) => {
+			output_base64(
+				attachment.encoded
+					? attachment.data
+					: Buffer.from(attachment.data).toString('base64'),
+				callback
+			);
+		};
+
+		const output_file = (attachment, next) => {
+			const chunk = MIME64CHUNK * 16;
+			const buffer = Buffer.alloc(chunk);
+			const closed = fd => {
+				if (fs.closeSync) {
+					fs.closeSync(fd);
+				}
+			};
+
+			const opened = (err, fd) => {
+				if (!err) {
+					const read = (err, bytes) => {
+						if (!err && this.readable) {
+							let encoding =
+								attachment && attachment.headers
+									? attachment.headers['content-transfer-encoding'] || 'base64'
+									: 'base64';
+							if (encoding === 'ascii' || encoding === '7bit') {
+								encoding = 'ascii';
+							} else if (encoding === 'binary' || encoding === '8bit') {
+								encoding = 'binary';
+							} else {
+								encoding = 'base64';
+							}
+							// guaranteed to be encoded without padding unless it is our last read
+							output_base64(buffer.toString(encoding, 0, bytes), () => {
+								if (bytes == chunk) {
+									// we read a full chunk, there might be more
+									fs.read(fd, buffer, 0, chunk, null, read);
+								} // that was the last chunk, we are done reading the file
+								else {
+									this.removeListener('error', closed);
+									fs.close(fd, next);
+								}
+							});
+						} else {
+							this.emit(
+								'error',
+								err || { message: 'message stream was interrupted somehow!' }
+							);
+						}
 					};
 
-          fs.read(fd, buffer, 0, chunk, null, read);
-          this.once('error', closed);
-        } else {
+					fs.read(fd, buffer, 0, chunk, null, read);
+					this.once('error', closed);
+				} else {
 					this.emit('error', err);
 				}
 			};
 
-      fs.open(attachment.path, 'r', opened);
+			fs.open(attachment.path, 'r', opened);
 		};
 
-    const output_stream = (attachment, callback) => {
-      if (attachment.stream.readable) {
+		const output_stream = (attachment, callback) => {
+			if (attachment.stream.readable) {
 				let previous = null;
 
-        attachment.stream.resume();
+				attachment.stream.resume();
 
 				attachment.stream.on('end', () => {
-          output_base64(
-            (previous || Buffer.from(0)).toString('base64'),
-            callback
-          );
-          this.removeListener('pause', attachment.stream.pause);
-          this.removeListener('resume', attachment.stream.resume);
-          this.removeListener('error', attachment.stream.resume);
+					output_base64(
+						(previous || Buffer.from(0)).toString('base64'),
+						callback
+					);
+					this.removeListener('pause', attachment.stream.pause);
+					this.removeListener('resume', attachment.stream.resume);
+					this.removeListener('error', attachment.stream.resume);
 				});
 
-        attachment.stream.on('data', (buffer) => {
-          // do we have bytes from a previous stream data event?
-          if (previous) {
-            const buffer2 = Buffer.concat([previous, buffer]);
-            previous = null; // free up the buffer
-            buffer = null; // free up the buffer
-            buffer = buffer2;
+				attachment.stream.on('data', buffer => {
+					// do we have bytes from a previous stream data event?
+					if (previous) {
+						const buffer2 = Buffer.concat([previous, buffer]);
+						previous = null; // free up the buffer
+						buffer = null; // free up the buffer
+						buffer = buffer2;
 					}
 
-          const padded = buffer.length % MIME64CHUNK;
-          // encode as much of the buffer to base64 without empty bytes
-          if (padded) {
-            previous = Buffer.alloc(padded);
-            // copy dangling bytes into previous buffer
-            buffer.copy(previous, 0, buffer.length - padded);
-          }
-          output_base64(buffer.toString('base64', 0, buffer.length - padded));
+					const padded = buffer.length % MIME64CHUNK;
+					// encode as much of the buffer to base64 without empty bytes
+					if (padded) {
+						previous = Buffer.alloc(padded);
+						// copy dangling bytes into previous buffer
+						buffer.copy(previous, 0, buffer.length - padded);
+					}
+					output_base64(buffer.toString('base64', 0, buffer.length - padded));
 				});
 
-        this.on('pause', attachment.stream.pause);
-        this.on('resume', attachment.stream.resume);
-        this.on('error', attachment.stream.resume);
-      } else {
+				this.on('pause', attachment.stream.pause);
+				this.on('resume', attachment.stream.resume);
+				this.on('error', attachment.stream.resume);
+			} else {
 				this.emit('error', { message: 'stream not readable' });
 			}
 		};
 
-    const output_base64 = (data, callback) => {
-      const loops = Math.ceil(data.length / MIMECHUNK);
-      let loop = 0;
-      while (loop < loops) {
-        output(data.substring(MIMECHUNK * loop, MIMECHUNK * (loop + 1)) + CRLF);
-        loop++;
-      }
-      if (callback) callback();
+		const output_base64 = (data, callback) => {
+			const loops = Math.ceil(data.length / MIMECHUNK);
+			let loop = 0;
+			while (loop < loops) {
+				output(data.substring(MIMECHUNK * loop, MIMECHUNK * (loop + 1)) + CRLF);
+				loop++;
+			}
+			if (callback) callback();
 		};
 
-    const output_text = (message) => {
-      let data = [];
-
-      data = data.concat(['Content-Type:', message.content, CRLF, 'Content-Transfer-Encoding: 7bit', CRLF]);
-      data = data.concat(['Content-Disposition: inline', CRLF, CRLF]);
-			data = data.concat([message.text || '', CRLF, CRLF]);
-
-      output(data.join(''));
-		};
-
-    const output_alternative = (message, callback) => {
-      const boundary = generate_boundary();
-      output(`Content-Type: multipart/alternative; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`);
-      output_text(message);
-			output(`--${boundary}${CRLF}`);
-
-      const finish = () => {
-        output([CRLF, '--', boundary, '--', CRLF, CRLF].join(''));
-        callback();
-			};
-
-      if (message.alternative.related) {
-        output_related(message.alternative, finish);
-      } else {
-        output_attachment(message.alternative, finish);
-      }
-		};
-
-    const output_related = (message, callback) => {
-			const boundary = generate_boundary();
-      output(`Content-Type: multipart/related; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`);
-      output_attachment(message, () => {
-        output_message(boundary, message.related, 0, () => {
-          output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
-          callback();
-        });
-      });
-		};
-
-    const output_header_data = () => {
-      if (this.message.attachments.length || this.message.alternative) {
-        output(`MIME-Version: 1.0${CRLF}`);
-        output_mixed();
-      } // you only have a text message!
-      else {
-        output_text(this.message);
-        close();
-      }
-		};
-
-    const output_header = () => {
+		const output_text = message => {
 			let data = [];
 
-      for (let header in this.message.header) {
-        // do not output BCC in the headers (regex) nor custom Object.prototype functions...
-				if (!/bcc/i.test(header) && this.message.header.hasOwnProperty(header)) {
-					data = data.concat([fix_header_name_case(header), ': ', this.message.header[header], CRLF]);
+			data = data.concat([
+				'Content-Type:',
+				message.content,
+				CRLF,
+				'Content-Transfer-Encoding: 7bit',
+				CRLF,
+			]);
+			data = data.concat(['Content-Disposition: inline', CRLF, CRLF]);
+			data = data.concat([message.text || '', CRLF, CRLF]);
+
+			output(data.join(''));
+		};
+
+		const output_alternative = (message, callback) => {
+			const boundary = generate_boundary();
+			output(
+				`Content-Type: multipart/alternative; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`
+			);
+			output_text(message);
+			output(`--${boundary}${CRLF}`);
+
+			const finish = () => {
+				output([CRLF, '--', boundary, '--', CRLF, CRLF].join(''));
+				callback();
+			};
+
+			if (message.alternative.related) {
+				output_related(message.alternative, finish);
+			} else {
+				output_attachment(message.alternative, finish);
+			}
+		};
+
+		const output_related = (message, callback) => {
+			const boundary = generate_boundary();
+			output(
+				`Content-Type: multipart/related; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`
+			);
+			output_attachment(message, () => {
+				output_message(boundary, message.related, 0, () => {
+					output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
+					callback();
+				});
+			});
+		};
+
+		const output_header_data = () => {
+			if (this.message.attachments.length || this.message.alternative) {
+				output(`MIME-Version: 1.0${CRLF}`);
+				output_mixed();
+			} // you only have a text message!
+			else {
+				output_text(this.message);
+				close();
+			}
+		};
+
+		const output_header = () => {
+			let data = [];
+
+			for (let header in this.message.header) {
+				// do not output BCC in the headers (regex) nor custom Object.prototype functions...
+				if (
+					!/bcc/i.test(header) &&
+					this.message.header.hasOwnProperty(header)
+				) {
+					data = data.concat([
+						fix_header_name_case(header),
+						': ',
+						this.message.header[header],
+						CRLF,
+					]);
 				}
 			}
 
-      output(data.join(''));
-      output_header_data();
+			output(data.join(''));
+			output_header_data();
 		};
 
-    const output = (data, callback, args) => {
+		const output = (data, callback, args) => {
 			const bytes = Buffer.byteLength(data);
 
-      // can we buffer the data?
-      if ((bytes + this.bufferIndex) < this.buffer.length) {
-        this.buffer.write(data, this.bufferIndex);
-        this.bufferIndex += bytes;
-        if (callback) callback.apply(null, args);
-      }
-      // we can't buffer the data, so ship it out!
-      else if (bytes > this.buffer.length) {
-        if (this.bufferIndex) {
-          this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
-          this.bufferIndex = 0;
+			// can we buffer the data?
+			if (bytes + this.bufferIndex < this.buffer.length) {
+				this.buffer.write(data, this.bufferIndex);
+				this.bufferIndex += bytes;
+				if (callback) callback.apply(null, args);
+			}
+			// we can't buffer the data, so ship it out!
+			else if (bytes > this.buffer.length) {
+				if (this.bufferIndex) {
+					this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+					this.bufferIndex = 0;
 				}
 
-        const loops = Math.ceil(data.length / this.buffer.length);
-        let loop = 0;
-        while (loop < loops) {
-          this.emit(
-            'data',
-            data.substring(
-              this.buffer.length * loop,
-              this.buffer.length * (loop + 1)
-            )
-          );
-          loop++;
-        }
-      } // we need to clean out the buffer, it is getting full
-      else {
-        if (!this.paused) {
-          this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
-          this.buffer.write(data, 0);
-          this.bufferIndex = bytes;
-          // we could get paused after emitting data...
-          if (this.paused) {
-            this.once('resume', () => callback.apply(null, args));
-          } else if (callback) {
-            callback.apply(null, args);
-          }
-        } // we can't empty out the buffer, so let's wait till we resume before adding to it
-        else {
-          this.once('resume', () => output(data, callback, args));
-        }
-      }
+				const loops = Math.ceil(data.length / this.buffer.length);
+				let loop = 0;
+				while (loop < loops) {
+					this.emit(
+						'data',
+						data.substring(
+							this.buffer.length * loop,
+							this.buffer.length * (loop + 1)
+						)
+					);
+					loop++;
+				}
+			} // we need to clean out the buffer, it is getting full
+			else {
+				if (!this.paused) {
+					this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+					this.buffer.write(data, 0);
+					this.bufferIndex = bytes;
+					// we could get paused after emitting data...
+					if (this.paused) {
+						this.once('resume', () => callback.apply(null, args));
+					} else if (callback) {
+						callback.apply(null, args);
+					}
+				} // we can't empty out the buffer, so let's wait till we resume before adding to it
+				else {
+					this.once('resume', () => output(data, callback, args));
+				}
+			}
 		};
 
-    const close = (err) => {
-      if (err) {
-        this.emit('error', err);
-      } else {
-        this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
-        this.emit('end');
-      }
-      this.buffer = null;
-      this.bufferIndex = 0;
-      this.readable = false;
-      this.removeAllListeners('resume');
-      this.removeAllListeners('pause');
-      this.removeAllListeners('error');
-      this.removeAllListeners('data');
-      this.removeAllListeners('end');
+		const close = err => {
+			if (err) {
+				this.emit('error', err);
+			} else {
+				this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+				this.emit('end');
+			}
+			this.buffer = null;
+			this.bufferIndex = 0;
+			this.readable = false;
+			this.removeAllListeners('resume');
+			this.removeAllListeners('pause');
+			this.removeAllListeners('error');
+			this.removeAllListeners('data');
+			this.removeAllListeners('end');
 		};
 
-    this.once('destroy', close);
-    process.nextTick(output_header);
+		this.once('destroy', close);
+		process.nextTick(output_header);
 	}
 
-  pause() {
-    this.paused = true;
-    this.emit('pause');
+	pause() {
+		this.paused = true;
+		this.emit('pause');
 	}
 
-  resume() {
-    this.paused = false;
-    this.emit('resume');
+	resume() {
+		this.paused = false;
+		this.emit('resume');
 	}
 
-  destroy() {
-    this.emit('destroy', this.bufferIndex > 0 ? { message: 'message stream destroyed' } : null);
+	destroy() {
+		this.emit(
+			'destroy',
+			this.bufferIndex > 0 ? { message: 'message stream destroyed' } : null
+		);
 	}
 
-  destroySoon() {
-    this.emit('destroy');
-  }
+	destroySoon() {
+		this.emit('destroy');
+	}
 }
 
 exports.Message = Message;

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -1,628 +1,513 @@
-var stream     = require('stream');
-var util       = require('util');
-var fs         = require('fs');
-var os         = require('os');
-var path       = require('path');
-var moment     = require('moment');
-var mimeWordEncode  = require('emailjs-mime-codec').mimeWordEncode;
-var addressparser = require('addressparser');
-var CRLF       = "\r\n";
-var MIMECHUNK  = 76; // MIME standard wants 76 char chunks when sending out.
-var BASE64CHUNK= 24; // BASE64 bits needed before padding is used
-var MIME64CHUNK= MIMECHUNK * 6; // meets both base64 and mime divisibility
-var BUFFERSIZE = MIMECHUNK*24*7; // size of the message stream buffer
-var counter    = 0;
+const { Stream } = require('stream');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const moment = require('moment');
+const mimeWordEncode = require('emailjs-mime-codec').mimeWordEncode;
+const addressparser = require('addressparser');
+const CRLF = '\r\n';
+const MIMECHUNK = 76; // MIME standard wants 76 char chunks when sending out.
+const BASE64CHUNK = 24; // BASE64 bits needed before padding is used
+const MIME64CHUNK = MIMECHUNK * 6; // meets both base64 and mime divisibility
+const BUFFERSIZE = MIMECHUNK * 24 * 7; // size of the message stream buffer
+
+let counter = 0;
 
 // support for nodejs without Buffer.concat native function
-if(!Buffer.concat)
-{
-   require("bufferjs/concat");
+if (!Buffer.concat) {
+  require('bufferjs/concat');
 }
 
-var generate_boundary = function()
-{
-   var text       = "";
-   var possible    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'()+_,-./:=?";
+function generate_boundary() {
+  let text = '';
+  const possible = `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'()+_,-./:=?`;
 
-   for(var i=0; i < 69; i++)
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
+  for (let i = 0; i < 69; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+	}
 
-   return text;
-};
-
-function person2address(l)
-{
-  var addresses = addressparser(l);
-  return addresses.map(function(addr) {
-    return addr.name ? mimeWordEncode(addr.name).replace(/,/g, '=2C') + ' ' + '<' + addr.address + '>' : addr.address;
-  }).join(', ');
+  return text;
 }
 
-var fix_header_name_case = function(header_name) {
-    return header_name.toLowerCase().replace(/^(.)|-(.)/g, function(match) {
-        return match.toUpperCase();
-    });
-};
+function person2address(l) {
+  return addressparser(l)
+    .map(({ name, address }) => {
+      return name
+        ? `${mimeWordEncode(name).replace(/,/g, '=2C')} <${address}>`
+        : address;
+    })
+    .join(', ');
+}
 
-var Message = function(headers)
-{
-   this.attachments  = [];
-   this.alternative  = null;
-   var now = new Date();
-   this.header       = {
-      "message-id":"<" + now.getTime() + "." + (counter++) + "." + process.pid + "@" + os.hostname() +">",
-      "date":moment().locale('en').format("ddd, DD MMM YYYY HH:mm:ss ZZ")
-   };
-   this.content      = "text/plain; charset=utf-8";
+function fix_header_name_case(header_name) {
+  return header_name
+    .toLowerCase()
+    .replace(/^(.)|-(.)/g, match => match.toUpperCase());
+}
 
-   for(var header in headers)
-   {
+class Message {
+  constructor(headers) {
+    this.attachments = [];
+    this.alternative = null;
+    this.header = {
+      'message-id': `<${new Date().getTime()}.${counter++}.${process.pid}@${os.hostname()}>`,
+      date: moment()
+        .locale('en')
+        .format('ddd, DD MMM YYYY HH:mm:ss ZZ')
+		};
+
+    this.content = 'text/plain; charset=utf-8';
+    for (let header in headers) {
       // allow user to override default content-type to override charset or send a single non-text message
-      if(/^content-type$/i.test(header))
-      {
-         this.content = headers[header];
+      if (/^content-type$/i.test(header)) {
+        this.content = headers[header];
+      } else if (header === 'text') {
+        this.text = headers[header];
+      } else if (header === 'attachment' && typeof headers[header] === 'object') {
+        if (Array.isArray(headers[header])) {
+          for (let i = 0, l = headers[header].length; i < l; i++) {
+            this.attach(headers[header][i]);
+          }
+        } else {
+          this.attach(headers[header]);
+        }
+      } else if (header === 'subject') {
+        this.header.subject = mimeWordEncode(headers.subject);
+      } else if (/^(cc|bcc|to|from)/i.test(header)) {
+        this.header[header.toLowerCase()] = person2address(headers[header]);
+      } else {
+        // allow any headers the user wants to set??
+        // if(/cc|bcc|to|from|reply-to|sender|subject|date|message-id/i.test(header))
+        this.header[header.toLowerCase()] = headers[header];
       }
-      else if(header == 'text')
-      {
-         this.text = headers[header];
-      }
-      else if(header == "attachment" && typeof (headers[header]) == "object")
-      {
-         if(Array.isArray(headers[header])) {
-            var that = this;
+		}
+	}
 
-            for (var i = 0, l = headers[header].length; i < l; i++) {
-              this.attach(headers[header][i]);
-            }
-         } else {
-            this.attach(headers[header]);
-         }
-      }
-      else if(header == 'subject')
-      {
-         this.header.subject = mimeWordEncode(headers.subject);
-      }
-      else if(/^(cc|bcc|to|from)/i.test(header))
-      {
-         this.header[header.toLowerCase()] = person2address(headers[header]);
-      }
-      else
-      {
-         // allow any headers the user wants to set??
-         // if(/cc|bcc|to|from|reply-to|sender|subject|date|message-id/i.test(header))
-         this.header[header.toLowerCase()] = headers[header];
-      }
-   }
-};
-
-Message.prototype =
-{
-   attach: function(options)
-   {
-      /*
+	attach(options) {
+    /*
          legacy support, will remove eventually...
          arguments -> (path, type, name, headers)
       */
-      if (arguments.length > 1)
-        options = {path:options, type:arguments[1], name:arguments[2]};
+    if (arguments.length > 1) {
+      options = { path: options, type: arguments[1], name: arguments[2] };
+		}
 
-      // sender can specify an attachment as an alternative
-      if(options.alternative)
-      {
-         this.alternative           = options;
-         this.alternative.charset   = options.charset || "utf-8";
-         this.alternative.type      = options.type || "text/html";
-         this.alternative.inline    = true;
-      }
-      else
-         this.attachments.push(options);
+    // sender can specify an attachment as an alternative
+    if (options.alternative) {
+      this.alternative = options;
+      this.alternative.charset = options.charset || 'utf-8';
+      this.alternative.type = options.type || 'text/html';
+      this.alternative.inline = true;
+    } else {
+			this.attachments.push(options);
+		}
 
-      return this;
-   },
+    return this;
+  }
 
-   /*
+  /*
       legacy support, will remove eventually...
       should use Message.attach() instead
    */
-   attach_alternative: function(html, charset)
-   {
-      this.alternative =
-      {
-         data:    html,
-         charset: charset || "utf-8",
-         type:    "text/html",
-         inline:  true
+  attach_alternative(html, charset) {
+    this.alternative = {
+      data: html,
+      charset: charset || 'utf-8',
+      type: 'text/html',
+      inline: true
+    };
+
+    return this;
+  }
+
+  valid(callback) {
+    if (!this.header.from) {
+      callback(false, 'message does not have a valid sender');
+		}
+
+    if (!(this.header.to || this.header.cc || this.header.bcc)) {
+      callback(false, 'message does not have a valid recipient');
+    } else if (this.attachments.length === 0) {
+      callback(true);
+    } else {
+      const failed = [];
+
+      this.attachments.forEach((attachment, index) => {
+        if (attachment.path) {
+          // migrating path->fs for existsSync)
+          if (!(fs.existsSync || path.existsSync)(attachment.path))
+            failed.push(`${attachment.path} does not exist`);
+        } else if (attachment.stream) {
+          if (!attachment.stream.readable)
+            failed.push('attachment stream is not readable');
+        } else if (!attachment.data) {
+          failed.push('attachment has no data associated with it');
+        }
+      });
+
+      callback(failed.length === 0, failed.join(', '));
+    }
+  }
+
+  stream() {
+    return new MessageStream(this);
+  }
+
+  read(callback) {
+    let buffer = '';
+    const str = this.stream();
+    str.on('data', (data) => buffer += data);
+    str.on('end', (err) => callback(err, buffer));
+    str.on('error', (err) => callback(err, buffer));
+  }
+}
+
+class MessageStream extends Stream {
+  constructor(message) {
+		super();
+
+    this.message = message;
+    this.readable = true;
+    this.paused = false;
+    this.buffer = Buffer.alloc(MIMECHUNK * 24 * 7);
+    this.bufferIndex = 0;
+
+    const output_mixed = () => {
+      const boundary = generate_boundary();
+      output(
+        `Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`
+      );
+
+      if (!this.message.alternative) {
+        output_text(this.message);
+        output_message(boundary, this.message.attachments, 0, close);
+      } else {
+        const cb = () => output_message(boundary, this.message.attachments, 0, close);
+        output_alternative(this.message, cb);
+      }
+    };
+
+    const output_message = (boundary, list, index, callback) => {
+      if (index < list.length) {
+        output(`--${boundary}${CRLF}`);
+        if (list[index].related) {
+          output_related(list[index], () =>
+            output_message(boundary, list, index + 1, callback)
+          );
+        } else {
+          output_attachment(list[index], () =>
+            output_message(boundary, list, index + 1, callback)
+          );
+        }
+      } else {
+        output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
+        callback();
+      }
+    };
+
+    const output_attachment_headers = attachment => {
+      let data = [];
+      const headers = {
+        'content-type':
+          attachment.type +
+          (attachment.charset ? `; charset=${attachment.charset}` : '') +
+          (attachment.method ? `; method=${attachment.method}` : ''),
+        'content-transfer-encoding': 'base64',
+        'content-disposition': attachment.inline
+          ? 'inline'
+          : `attachment; filename="${mimeWordEncode(attachment.name)}"`
       };
 
-      return this;
-   },
-
-   valid: function(callback)
-   {
-      var self = this;
-
-      if(!self.header.from)
-      {
-         callback(false, "message does not have a valid sender");
-      }
-      if(!(self.header.to || self.header.cc || self.header.bcc))
-      {
-         callback(false, "message does not have a valid recipient");
-      }
-      else if(self.attachments.length === 0)
-      {
-         callback(true);
-      }
-      else
-      {
-         var check  = [];
-         var failed = [];
-
-         self.attachments.forEach(function(attachment, index)
-         {
-            if(attachment.path)
-            {
-               // migrating path->fs for existsSync)
-               if(!(fs.existsSync || path.existsSync)(attachment.path))
-                  failed.push(attachment.path + " does not exist");
-            }
-            else if(attachment.stream)
-            {
-               if(!attachment.stream.readable)
-                  failed.push("attachment stream is not readable");
-            }
-            else if(!attachment.data)
-            {
-               failed.push("attachment has no data associated with it");
-            }
-         });
-
-         callback(failed.length === 0, failed.join(", "));
-      }
-   },
-
-   stream: function()
-   {
-      return new MessageStream(this);
-   },
-
-   read: function(callback)
-   {
-      var buffer = "";
-
-      var capture = function(data)
-      {
-         buffer += data;
-      };
-
-      var output = function(err)
-      {
-         callback(err, buffer);
-      };
-
-      var str = this.stream();
-
-      str.on('data', capture);
-      str.on('end', output);
-      str.on('error', output);
-   }
-};
-
-var MessageStream = function(message)
-{
-   var self       = this;
-
-   stream.Stream.call(self);
-
-   self.message   = message;
-   self.readable  = true;
-   self.paused    = false;
-   self.buffer    = new Buffer(MIMECHUNK*24*7);
-   self.bufferIndex = 0;
-
-   var output_process = function(next, args)
-   {
-      if(self.paused)
-      {
-         self.resumed = function() { next.apply(null, args); };
-      }
-      else
-      {
-         next.apply(null, args);
+      for (let header in attachment.headers || {}) {
+        // allow sender to override default headers
+        headers[header.toLowerCase()] = attachment.headers[header];
       }
 
-      next.apply(null, args);
-   };
-
-   var output_mixed = function()
-   {
-      var boundary   = generate_boundary();
-      var data       = ["Content-Type: multipart/mixed; boundary=\"", boundary, "\"", CRLF, CRLF, "--", boundary, CRLF];
-
-      output(data.join(''));
-
-      if(!self.message.alternative)
-      {
-         output_text(self.message);
-         output_message(boundary, self.message.attachments, 0, close);
-      }
-      else
-      {
-         output_alternative(self.message, function() { output_message(boundary, self.message.attachments, 0, close); });
-      }
-   };
-
-   var output_message = function(boundary, list, index, callback)
-   {
-      if(index < list.length)
-      {
-         output(["--", boundary, CRLF].join(''));
-
-         if(list[index].related)
-         {
-            output_related(list[index], function() { output_message(boundary, list, index + 1, callback); });
-         }
-         else
-         {
-            output_attachment(list[index], function() { output_message(boundary, list, index + 1, callback); });
-         }
-      }
-      else
-      {
-         output([CRLF, "--", boundary, "--", CRLF, CRLF].join(''));
-         callback();
-      }
-   };
-
-   var output_attachment_headers = function(attachment)
-   {
-      var data = [],
-          header,
-          headers =
-          {
-            'content-type': attachment.type +
-              (attachment.charset ? "; charset=" + attachment.charset : "") +
-              (attachment.method ? "; method=" + attachment.method : ""),
-            'content-transfer-encoding': 'base64',
-            'content-disposition': attachment.inline ? 'inline' : 'attachment; filename="' + mimeWordEncode(attachment.name) + '"'
-          };
-
-      for(header in (attachment.headers || {}))
-      {
-         // allow sender to override default headers
-         headers[header.toLowerCase()] = attachment.headers[header];
-      }
-
-      for(header in headers)
-      {
-         data = data.concat([fix_header_name_case(header), ': ', headers[header], CRLF]);
+      for (let header in headers) {
+        data = data.concat([
+          fix_header_name_case(header),
+          ': ',
+          headers[header],
+          CRLF
+        ]);
       }
 
       output(data.concat([CRLF]).join(''));
-   };
+    };
 
-   var output_attachment = function(attachment, callback)
-   {
-      var build = attachment.path ? output_file : attachment.stream ? output_stream : output_data;
+    const output_attachment = (attachment, callback) => {
+      const build = attachment.path
+        ? output_file
+        : attachment.stream
+          ? output_stream
+          : output_data;
       output_attachment_headers(attachment);
       build(attachment, callback);
-   };
+		};
 
-   var output_data = function(attachment, callback)
-   {
-      output_base64(attachment.encoded ? attachment.data : new Buffer(attachment.data).toString("base64"), callback);
-   };
+    const output_data = (attachment, callback) => {
+      output_base64(
+        attachment.encoded
+          ? attachment.data
+          : Buffer.from(attachment.data).toString('base64'),
+        callback
+      );
+		};
 
-   var output_file = function(attachment, next)
-   {
-      var chunk      = MIME64CHUNK*16;
-      var buffer     = new Buffer(chunk);
-      var closed     = function(fd) { if(fs.closeSync) { fs.closeSync(fd); } };
-      var opened     = function(err, fd)
-      {
-         if(!err)
-         {
-            var read = function(err, bytes)
-            {
-               if(!err && self.readable)
-               {
-                  var encoding = attachment && attachment.headers ? attachment.headers['content-transfer-encoding'] || 'base64' : 'base64';
+    const output_file = (attachment, next) => {
+      const chunk = MIME64CHUNK * 16;
+      const buffer = Buffer.alloc(chunk);
+      const closed = (fd) => {
+        if (fs.closeSync) {
+          fs.closeSync(fd);
+        }
+			};
 
-                  if (encoding === 'ascii' || encoding === '7bit')  {
-                    encoding = 'ascii';
-                  } else if(encoding === 'binary' || encoding === '8bit')  {
-                    encoding = 'binary';
-                  } else {
-                    encoding = 'base64';
-                  }
+      const opened = (err, fd) => {
+        if (!err) {
+          const read = (err, bytes) => {
+            if (!err && this.readable) {
+              let encoding =
+                attachment && attachment.headers
+                  ? attachment.headers['content-transfer-encoding'] || 'base64'
+                  : 'base64';
+              if (encoding === 'ascii' || encoding === '7bit') {
+                encoding = 'ascii';
+              } else if (encoding === 'binary' || encoding === '8bit') {
+                encoding = 'binary';
+              } else {
+                encoding = 'base64';
+              }
+              // guaranteed to be encoded without padding unless it is our last read
+              output_base64(buffer.toString(encoding, 0, bytes), () => {
+                if (bytes == chunk) {
+                  // we read a full chunk, there might be more
+                  fs.read(fd, buffer, 0, chunk, null, read);
+                } // that was the last chunk, we are done reading the file
+                else {
+                  this.removeListener('error', closed);
+                  fs.close(fd, next);
+                }
+              });
+            } else {
+              this.emit('error', err || { message: 'message stream was interrupted somehow!' });
+            }
+					};
 
-                  // guaranteed to be encoded without padding unless it is our last read
-                  output_base64(buffer.toString(encoding, 0, bytes), function()
-                  {
-                     if(bytes == chunk) // we read a full chunk, there might be more
-                     {
-                        fs.read(fd, buffer, 0, chunk, null, read);
-                     }
-                     else // that was the last chunk, we are done reading the file
-                     {
-                        self.removeListener("error", closed);
-                        fs.close(fd, next);
-                     }
-                  });
-               }
-               else
-               {
-                  self.emit('error', err || {message:"message stream was interrupted somehow!"});
-               }
-            };
-
-            fs.read(fd, buffer, 0, chunk, null, read);
-            self.once("error", closed);
-         }
-         else
-            self.emit('error', err);
-      };
+          fs.read(fd, buffer, 0, chunk, null, read);
+          this.once('error', closed);
+        } else {
+					this.emit('error', err);
+				}
+			};
 
       fs.open(attachment.path, 'r', opened);
-   };
+		};
 
-   var output_stream = function(attachment, callback)
-   {
-      if(attachment.stream.readable)
-      {
-         var previous = null;
+    const output_stream = (attachment, callback) => {
+      if (attachment.stream.readable) {
+				let previous = null;
 
-         attachment.stream.resume();
-         attachment.stream.on('end', function()
-         {
-            output_base64((previous || new Buffer(0)).toString("base64"), callback);
-            self.removeListener('pause', attachment.stream.pause);
-            self.removeListener('resume', attachment.stream.resume);
-            self.removeListener('error', attachment.stream.resume);
-         });
+        attachment.stream.resume();
 
-         attachment.stream.on('data', function(buffer)
-         {
-            // do we have bytes from a previous stream data event?
-            if(previous)
-            {
-               var buffer2 = Buffer.concat([previous, buffer]);
-               previous    = null; // free up the buffer
-               buffer      = null; // free up the buffer
-               buffer      = buffer2;
-            }
+				attachment.stream.on('end', () => {
+          output_base64(
+            (previous || Buffer.from(0)).toString('base64'),
+            callback
+          );
+          this.removeListener('pause', attachment.stream.pause);
+          this.removeListener('resume', attachment.stream.resume);
+          this.removeListener('error', attachment.stream.resume);
+				});
 
-            var padded = buffer.length % (MIME64CHUNK);
+        attachment.stream.on('data', (buffer) => {
+          // do we have bytes from a previous stream data event?
+          if (previous) {
+            const buffer2 = Buffer.concat([previous, buffer]);
+            previous = null; // free up the buffer
+            buffer = null; // free up the buffer
+            buffer = buffer2;
+					}
 
-            // encode as much of the buffer to base64 without empty bytes
-            if(padded)
-            {
-               previous = new Buffer(padded);
-               // copy dangling bytes into previous buffer
-               buffer.copy(previous, 0, buffer.length - padded);
-            }
+          const padded = buffer.length % MIME64CHUNK;
+          // encode as much of the buffer to base64 without empty bytes
+          if (padded) {
+            previous = Buffer.alloc(padded);
+            // copy dangling bytes into previous buffer
+            buffer.copy(previous, 0, buffer.length - padded);
+          }
+          output_base64(buffer.toString('base64', 0, buffer.length - padded));
+				});
 
-            output_base64(buffer.toString("base64", 0, buffer.length - padded));
-         });
+        this.on('pause', attachment.stream.pause);
+        this.on('resume', attachment.stream.resume);
+        this.on('error', attachment.stream.resume);
+      } else {
+				this.emit('error', { message: 'stream not readable' });
+			}
+		};
 
-         self.on('pause', attachment.stream.pause);
-         self.on('resume', attachment.stream.resume);
-         self.on('error', attachment.stream.resume);
-      }
-      else
-         self.emit('error', {message:"stream not readable"});
-   };
-
-   var output_base64 = function(data, callback)
-   {
-      var loops   = Math.ceil(data.length / MIMECHUNK);
-      var loop    = 0;
-
-      while(loop < loops)
-      {
+    const output_base64 = (data, callback) => {
+      const loops = Math.ceil(data.length / MIMECHUNK);
+      let loop = 0;
+      while (loop < loops) {
         output(data.substring(MIMECHUNK * loop, MIMECHUNK * (loop + 1)) + CRLF);
         loop++;
       }
+      if (callback) callback();
+		};
 
-      if(callback)
-        callback();
-   };
+    const output_text = (message) => {
+      let data = [];
 
-   var output_text = function(message)
-   {
-      var data = [];
-
-      data = data.concat(["Content-Type:", message.content, CRLF, "Content-Transfer-Encoding: 7bit", CRLF]);
-      data = data.concat(["Content-Disposition: inline", CRLF, CRLF]);
-      data = data.concat([message.text || "", CRLF, CRLF]);
+      data = data.concat(['Content-Type:', message.content, CRLF, 'Content-Transfer-Encoding: 7bit', CRLF]);
+      data = data.concat(['Content-Disposition: inline', CRLF, CRLF]);
+			data = data.concat([message.text || '', CRLF, CRLF]);
 
       output(data.join(''));
-   };
+		};
 
-   var output_alternative = function(message, callback)
-   {
-      var data = [], boundary = generate_boundary();
-
-      data     = data.concat(["Content-Type: multipart/alternative; boundary=\"", boundary, "\"", CRLF, CRLF]);
-      data     = data.concat(["--", boundary, CRLF]);
-
-      output(data.join(''));
+    const output_alternative = (message, callback) => {
+      const boundary = generate_boundary();
+      output(`Content-Type: multipart/alternative; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`);
       output_text(message);
-      output(["--", boundary, CRLF].join(''));
+			output(`--${boundary}${CRLF}`);
 
-      var finish = function()
-      {
-         output([CRLF, "--", boundary, "--", CRLF, CRLF].join(''));
-         callback();
-      };
+      const finish = () => {
+        output([CRLF, '--', boundary, '--', CRLF, CRLF].join(''));
+        callback();
+			};
 
-      if(message.alternative.related)
-      {
-         output_related(message.alternative, finish);
+      if (message.alternative.related) {
+        output_related(message.alternative, finish);
+      } else {
+        output_attachment(message.alternative, finish);
       }
-      else
-      {
-         output_attachment(message.alternative, finish);
-      }
-   };
+		};
 
-   var output_related = function(message, callback)
-   {
-      var data = [], boundary = generate_boundary();
-
-      data     = data.concat(["Content-Type: multipart/related; boundary=\"", boundary, "\"", CRLF, CRLF]);
-      data     = data.concat(["--", boundary, CRLF]);
-
-      output(data.join(''));
-
-      output_attachment(message, function()
-      {
-         output_message(boundary, message.related, 0, function()
-         {
-            output([CRLF, "--", boundary, "--", CRLF, CRLF].join(''));
-            callback();
-         });
+    const output_related = (message, callback) => {
+			const boundary = generate_boundary();
+      output(`Content-Type: multipart/related; boundary="${boundary}"${CRLF}${CRLF}--${boundary}${CRLF}`);
+      output_attachment(message, () => {
+        output_message(boundary, message.related, 0, () => {
+          output(`${CRLF}--${boundary}--${CRLF}${CRLF}`);
+          callback();
+        });
       });
-   };
+		};
 
-   var output_header_data = function()
-   {
-      if(self.message.attachments.length || self.message.alternative)
-      {
-         output("MIME-Version: 1.0" + CRLF);
-         output_mixed();
+    const output_header_data = () => {
+      if (this.message.attachments.length || this.message.alternative) {
+        output(`MIME-Version: 1.0${CRLF}`);
+        output_mixed();
+      } // you only have a text message!
+      else {
+        output_text(this.message);
+        close();
       }
-      else // you only have a text message!
-      {
-         output_text(self.message);
-         close();
-      }
-   };
+		};
 
-   var output_header = function()
-   {
-      var data = [];
+    const output_header = () => {
+			let data = [];
 
-      for(var header in self.message.header)
-      {
-         // do not output BCC in the headers (regex) nor custom Object.prototype functions...
-         if(!(/bcc/i.test(header)) && self.message.header.hasOwnProperty (header))
-            data = data.concat([fix_header_name_case(header), ": ", self.message.header[header], CRLF]);
-      }
+      for (let header in this.message.header) {
+        // do not output BCC in the headers (regex) nor custom Object.prototype functions...
+				if (!/bcc/i.test(header) && this.message.header.hasOwnProperty(header)) {
+					data = data.concat([fix_header_name_case(header), ': ', this.message.header[header], CRLF]);
+				}
+			}
 
       output(data.join(''));
       output_header_data();
-   };
+		};
 
-   var output = function(data, callback, args)
-   {
-      var bytes = Buffer.byteLength(data);
+    const output = (data, callback, args) => {
+			const bytes = Buffer.byteLength(data);
 
       // can we buffer the data?
-      if(bytes + self.bufferIndex < self.buffer.length)
-      {
-         self.buffer.write(data, self.bufferIndex);
-         self.bufferIndex += bytes;
-
-         if(callback)
-            callback.apply(null, args);
+      if ((bytes + this.bufferIndex) < this.buffer.length) {
+        this.buffer.write(data, this.bufferIndex);
+        this.bufferIndex += bytes;
+        if (callback) callback.apply(null, args);
       }
       // we can't buffer the data, so ship it out!
-      else if(bytes > self.buffer.length)
-      {
-         if(self.bufferIndex)
-         {
-            self.emit('data', self.buffer.toString("utf-8", 0, self.bufferIndex));
-            self.bufferIndex = 0;
-         }
+      else if (bytes > this.buffer.length) {
+        if (this.bufferIndex) {
+          this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+          this.bufferIndex = 0;
+				}
 
-         var loops   = Math.ceil(data.length / self.buffer.length);
-         var loop    = 0;
-
-         while(loop < loops)
-         {
-           self.emit('data', data.substring(self.buffer.length*loop, self.buffer.length*(loop + 1)));
-           loop++;
-         }
+        const loops = Math.ceil(data.length / this.buffer.length);
+        let loop = 0;
+        while (loop < loops) {
+          this.emit(
+            'data',
+            data.substring(
+              this.buffer.length * loop,
+              this.buffer.length * (loop + 1)
+            )
+          );
+          loop++;
+        }
+      } // we need to clean out the buffer, it is getting full
+      else {
+        if (!this.paused) {
+          this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+          this.buffer.write(data, 0);
+          this.bufferIndex = bytes;
+          // we could get paused after emitting data...
+          if (this.paused) {
+            this.once('resume', () => callback.apply(null, args));
+          } else if (callback) {
+            callback.apply(null, args);
+          }
+        } // we can't empty out the buffer, so let's wait till we resume before adding to it
+        else {
+          this.once('resume', () => output(data, callback, args));
+        }
       }
-      else // we need to clean out the buffer, it is getting full
-      {
-         if(!self.paused)
-         {
-            self.emit('data', self.buffer.toString("utf-8", 0, self.bufferIndex));
-            self.buffer.write(data, 0);
-            self.bufferIndex = bytes;
+		};
 
-            // we could get paused after emitting data...
-            if(self.paused)
-            {
-               self.once("resume", function() { callback.apply(null, args); });
-            }
-            else if(callback)
-            {
-               callback.apply(null, args);
-            }
-         }
-         else // we can't empty out the buffer, so let's wait till we resume before adding to it
-         {
-            self.once("resume", function() { output(data, callback, args); });
-         }
+    const close = (err) => {
+      if (err) {
+        this.emit('error', err);
+      } else {
+        this.emit('data', this.buffer.toString('utf-8', 0, this.bufferIndex));
+        this.emit('end');
       }
-   };
+      this.buffer = null;
+      this.bufferIndex = 0;
+      this.readable = false;
+      this.removeAllListeners('resume');
+      this.removeAllListeners('pause');
+      this.removeAllListeners('error');
+      this.removeAllListeners('data');
+      this.removeAllListeners('end');
+		};
 
-   var close = function(err)
-   {
-      if(err)
-      {
-         self.emit("error", err);
-      }
-      else
-      {
-         self.emit('data', self.buffer.toString("utf-8", 0, self.bufferIndex));
-         self.emit('end');
-      }
+    this.once('destroy', close);
+    process.nextTick(output_header);
+	}
 
-      self.buffer = null;
-      self.bufferIndex = 0;
-      self.readable = false;
-      self.removeAllListeners("resume");
-      self.removeAllListeners("pause");
-      self.removeAllListeners("error");
-      self.removeAllListeners("data");
-      self.removeAllListeners("end");
-   };
+  pause() {
+    this.paused = true;
+    this.emit('pause');
+	}
 
-   self.once("destroy", close);
-   process.nextTick(output_header);
-};
+  resume() {
+    this.paused = false;
+    this.emit('resume');
+	}
 
-util.inherits(MessageStream, stream.Stream);
+  destroy() {
+    this.emit('destroy', this.bufferIndex > 0 ? { message: 'message stream destroyed' } : null);
+	}
 
-MessageStream.prototype.pause = function()
-{
-   this.paused = true;
-   this.emit('pause');
-};
-
-MessageStream.prototype.resume = function()
-{
-   this.paused = false;
-   this.emit('resume');
-};
-
-MessageStream.prototype.destroy = function()
-{
-   this.emit("destroy", self.bufferIndex > 0 ? {message:"message stream destroyed"} : null);
-};
-
-MessageStream.prototype.destroySoon = function()
-{
-   this.emit("destroy");
-};
+  destroySoon() {
+    this.emit('destroy');
+  }
+}
 
 exports.Message = Message;
 exports.BUFFERSIZE = BUFFERSIZE;
-exports.create = function(headers)
-{
-   return new Message(headers);
-};
+exports.create = headers => new Message(headers);

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -1,81 +1,68 @@
-var SMTPError = require('./error');
+const SMTPError = require('./error');
 
-var SMTPResponse = function(stream, timeout, onerror) 
-{
-  var buffer = '',
+class SMTPResponse {
+	constructor(stream, timeout, onerror) {
+		let buffer = '';
 
-  notify = function()
-  {
-    if(buffer.length)
-    {
-      // parse buffer for response codes
-      var line = buffer.replace("\r", '');
-        
-      if(!line.trim().split(/\n/).pop().match(/^(\d{3})\s/))
-          return;
-        
-      var match = line ? line.match(/(\d+)\s?(.*)/) : null;
+		const notify = () => {
+			if (buffer.length) {
+				// parse buffer for response codes
+				const line = buffer.replace('\r', '');
+				if (!line.trim().split(/\n/).pop().match(/^(\d{3})\s/)) {
+					return;
+				}
 
-      stream.emit('response', null, match ? {code:match[1], message:match[2], data:line} : {code:-1, data:line});
-      buffer = '';
-    }
-  },
+				const match = line ? line.match(/(\d+)\s?(.*)/) : null;
+				const data = match !== null
+					? { code: match[1], message: match[2], data: line }
+					: { code: -1, data: line };
 
-  error = function(err)
-  {
-    stream.emit('response', SMTPError('connection encountered an error', SMTPError.ERROR, err));
-  },
+				stream.emit('response', null, data);
+				buffer = '';
+			}
+		};
 
-  timedout = function(err)
-  {
-    stream.end();
-    stream.emit('response', SMTPError('timedout while connecting to smtp server', SMTPError.TIMEDOUT, err));
-  },
+		const error = (err) => {
+			stream.emit('response', SMTPError('connection encountered an error', SMTPError.ERROR, err));
+		}
 
-  watch = function(data)
-  {
-    //var data = stream.read();
-    if (data !== null) {
-      var decoded = data.toString();
-      var emit		= false;
-      var code		= 0;
+		const timedout = (err) => {
+			stream.end();
+			stream.emit('response', SMTPError('timedout while connecting to smtp server', SMTPError.TIMEDOUT, err));
+		}
 
-      buffer += decoded;
-      notify();
-    }
-  },
+		const watch = (data) => {
+			if (data !== null) {
+				buffer += data.toString();
+				notify();
+			}
+		};
 
-  close = function(err)
-  {
-    stream.emit('response', SMTPError('connection has closed', SMTPError.CONNECTIONCLOSED, err));
-  },
+		const close = (err) => {
+			stream.emit('response', SMTPError('connection has closed', SMTPError.CONNECTIONCLOSED, err));
+		};
 
-  end = function(err)
-  {
-    stream.emit('response', SMTPError('connection has ended', SMTPError.CONNECTIONENDED, err));
-  };
+		const end = (err) => {
+			stream.emit('response', SMTPError('connection has ended', SMTPError.CONNECTIONENDED, err));
+		};
 
-  this.stop = function(err) {
-    stream.removeAllListeners('response');
-    //stream.removeListener('readable', watch);
-    stream.removeListener('data', watch);
-    stream.removeListener('end', end);
-    stream.removeListener('close', close);
-    stream.removeListener('error', error);
+		this.stop = (err) => {
+			stream.removeAllListeners('response');
+			stream.removeListener('data', watch);
+			stream.removeListener('end', end);
+			stream.removeListener('close', close);
+			stream.removeListener('error', error);
 
-    if(err && typeof(onerror) == "function")
-      onerror(err);
-  };
+			if (err && typeof onerror === 'function')
+				onerror(err);
+		};
 
-  //stream.on('readable', watch);
-  stream.on('data', watch);
-  stream.on('end', end);
-  stream.on('close', close);
-  stream.on('error', error);
-  stream.setTimeout(timeout, timedout);
-};
+		stream.on('data', watch);
+		stream.on('end', end);
+		stream.on('close', close);
+		stream.on('error', error);
+		stream.setTimeout(timeout, timedout);
+	}
+}
 
-exports.monitor = function(stream, timeout, onerror) 
-{
-  return new SMTPResponse(stream, timeout, onerror);
-};
+exports.monitor = (stream, timeout, onerror) => new SMTPResponse(stream, timeout, onerror);

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -8,53 +8,75 @@ class SMTPResponse {
 			if (buffer.length) {
 				// parse buffer for response codes
 				const line = buffer.replace('\r', '');
-				if (!line.trim().split(/\n/).pop().match(/^(\d{3})\s/)) {
+				if (
+					!line
+						.trim()
+						.split(/\n/)
+						.pop()
+						.match(/^(\d{3})\s/)
+				) {
 					return;
 				}
 
 				const match = line ? line.match(/(\d+)\s?(.*)/) : null;
-				const data = match !== null
-					? { code: match[1], message: match[2], data: line }
-					: { code: -1, data: line };
+				const data =
+					match !== null
+						? { code: match[1], message: match[2], data: line }
+						: { code: -1, data: line };
 
 				stream.emit('response', null, data);
 				buffer = '';
 			}
 		};
 
-		const error = (err) => {
-			stream.emit('response', SMTPError('connection encountered an error', SMTPError.ERROR, err));
-		}
+		const error = err => {
+			stream.emit(
+				'response',
+				SMTPError('connection encountered an error', SMTPError.ERROR, err)
+			);
+		};
 
-		const timedout = (err) => {
+		const timedout = err => {
 			stream.end();
-			stream.emit('response', SMTPError('timedout while connecting to smtp server', SMTPError.TIMEDOUT, err));
-		}
+			stream.emit(
+				'response',
+				SMTPError(
+					'timedout while connecting to smtp server',
+					SMTPError.TIMEDOUT,
+					err
+				)
+			);
+		};
 
-		const watch = (data) => {
+		const watch = data => {
 			if (data !== null) {
 				buffer += data.toString();
 				notify();
 			}
 		};
 
-		const close = (err) => {
-			stream.emit('response', SMTPError('connection has closed', SMTPError.CONNECTIONCLOSED, err));
+		const close = err => {
+			stream.emit(
+				'response',
+				SMTPError('connection has closed', SMTPError.CONNECTIONCLOSED, err)
+			);
 		};
 
-		const end = (err) => {
-			stream.emit('response', SMTPError('connection has ended', SMTPError.CONNECTIONENDED, err));
+		const end = err => {
+			stream.emit(
+				'response',
+				SMTPError('connection has ended', SMTPError.CONNECTIONENDED, err)
+			);
 		};
 
-		this.stop = (err) => {
+		this.stop = err => {
 			stream.removeAllListeners('response');
 			stream.removeListener('data', watch);
 			stream.removeListener('end', end);
 			stream.removeListener('close', close);
 			stream.removeListener('error', error);
 
-			if (err && typeof onerror === 'function')
-				onerror(err);
+			if (err && typeof onerror === 'function') onerror(err);
 		};
 
 		stream.on('data', watch);
@@ -65,4 +87,5 @@ class SMTPResponse {
 	}
 }
 
-exports.monitor = (stream, timeout, onerror) => new SMTPResponse(stream, timeout, onerror);
+exports.monitor = (stream, timeout, onerror) =>
+	new SMTPResponse(stream, timeout, onerror);

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -76,7 +76,9 @@ class SMTPResponse {
 			stream.removeListener('close', close);
 			stream.removeListener('error', error);
 
-			if (err && typeof onerror === 'function') onerror(err);
+			if (err && typeof onerror === 'function') {
+				onerror(err);
+			}
 		};
 
 		stream.on('data', watch);

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -1,30 +1,30 @@
 /*
  * SMTP class written using python's (2.7) smtplib.py as a base
  */
-var net = require('net');
-var crypto = require('crypto');
-var os = require('os');
-var tls = require('tls');
-var util = require('util');
-var events = require('events');
+const net = require('net');
+const crypto = require('crypto');
+const os = require('os');
+const tls = require('tls');
+const { EventEmitter } = require('events');
 
-var SMTPResponse = require('./response');
-var SMTPError = require('./error');
+const SMTPResponse = require('./response');
+const SMTPError = require('./error');
 
-var SMTP_PORT = 25;
-var SMTP_SSL_PORT = 465;
-var SMTP_TLS_PORT = 587;
-var CRLF = "\r\n";
-var AUTH_METHODS = {
+const SMTP_PORT = 25;
+const SMTP_SSL_PORT = 465;
+const SMTP_TLS_PORT = 587;
+const CRLF = '\r\n';
+const AUTH_METHODS = {
   PLAIN: 'PLAIN',
   CRAM_MD5: 'CRAM-MD5',
   LOGIN: 'LOGIN',
   XOAUTH2: 'XOAUTH2'
 };
-var TIMEOUT = 5000;
-var DEBUG = 0;
 
-var log = function() {
+const TIMEOUT = 5000;
+let DEBUG = 0;
+
+const log = function() {
   if (DEBUG) {
     Array.prototype.slice.call(arguments).forEach(function(d) {
       console.log(d);
@@ -32,7 +32,7 @@ var log = function() {
   }
 };
 
-var quotedata = function(data) {
+const quotedata = function(data) {
   // Quote data for email.
   // Double leading '.', and change Unix newline '\\n', or Mac '\\r' into
   // Internet CRLF end-of-line.
@@ -40,274 +40,268 @@ var quotedata = function(data) {
   return data.replace(/(?:\r\n|\n|\r(?!\n))/g, CRLF).replace(/^\./gm, '..');
 };
 
-var caller = function(callback) {
+const caller = function(callback) {
   if (typeof(callback) == 'function') {
-    var args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(arguments);
     args.shift();
 
     callback.apply(null, args);
   }
 };
 
-var SMTPState = {
+const SMTPState = {
   NOTCONNECTED: 0,
   CONNECTING: 1,
   CONNECTED: 2
 };
 
-var SMTP = function(options) {
-  events.EventEmitter.call(this);
+class SMTP extends EventEmitter {
+	constructor(options = {}) {
+		super();
 
-  options = options || {};
+		const {
+			timeout,
+			user,
+			password,
+			domain,
+			host,
+			port,
+			ssl,
+			tls,
+			authentication,
+		} = Object.assign({
+			timeout: TIMEOUT,
+			domain: os.hostname(),
+			host: 'localhost',
+			ssl: false,
+			tls: false,
+			authentication: [
+				AUTH_METHODS.CRAM_MD5,
+				AUTH_METHODS.LOGIN,
+				AUTH_METHODS.PLAIN,
+				AUTH_METHODS.XOAUTH2,
+			],
+		}, options);
 
-  this.sock = null;
-  this.timeout = options.timeout || TIMEOUT;
-  this.features = null;
-  this._state = SMTPState.NOTCONNECTED;
-  this._secure = false;
-  this.loggedin = (options.user && options.password) ? false : true;
-  this.domain = options.domain || os.hostname();
-  this.host = options.host || 'localhost';
-  this.port = options.port || (options.ssl ? SMTP_SSL_PORT : options.tls ? SMTP_TLS_PORT : SMTP_PORT);
-  this.ssl = options.ssl || false;
-  this.tls = options.tls || false;
-  this.monitor = null;
-  this.authentication = options.authentication || [AUTH_METHODS.CRAM_MD5, AUTH_METHODS.LOGIN, AUTH_METHODS.PLAIN, AUTH_METHODS.XOAUTH2];
+		this._state = SMTPState.NOTCONNECTED;
+		this._secure = false;
 
-  // keep these strings hidden when quicky debugging/logging
-  this.user = function() {
-    return options.user;
-  };
-  this.password = function() {
-    return options.password;
-  };
-};
+		this.sock = null;
+		this.features = null;
+		this.monitor = null;
 
-SMTP.prototype = {
-  debug: function(level) {
-    DEBUG = level;
-  },
+		this.authentication = authentication;
+		this.timeout = timeout;
+		this.domain = domain;
+		this.host = host;
+		this.ssl = ssl;
+		this.tls = tls;
 
-  state: function() {
+		this.port = port || (ssl ? SMTP_SSL_PORT : tls ? SMTP_TLS_PORT : SMTP_PORT);
+		this.loggedin = (user && password) ? false : true;
+
+		// keep these strings hidden when quicky debugging/logging
+		this.user = () => options.user;
+		this.password = () => options.password;
+	}
+
+	debug(level) {
+  	DEBUG = level;
+  }
+
+  state() {
     return this._state;
-  },
+  }
 
-  authorized: function() {
+  authorized() {
     return this.loggedin;
-  },
+  }
 
-  connect: function(callback, port, host, options) {
+  connect(callback, port, host, options) {
     options = options || {};
 
-    var self = this;
+    this.host = host || this.host;
+    this.port = port || this.port;
+    this.ssl = options.ssl || this.ssl;
 
-    self.host = host || self.host;
-    self.port = port || self.port;
-    self.ssl = options.ssl || self.ssl;
-
-    if (self._state != SMTPState.NOTCONNECTED) {
-      self.quit(function() {
-        self.connect(callback, port, host, options);
-      });
+    if (this._state != SMTPState.NOTCONNECTED) {
+      this.quit(() => this.connect(callback, port, host, options));
       return;
     }
 
-    var connected = function(err) {
+    const connected = (err) => {
       if (!err) {
-        log("connected: " + self.host + ":" + self.port);
+        log(`connected: ${this.host}:${this.port}`);
 
-        if (self.ssl && !self.tls) {
+        if (this.ssl && !this.tls) {
           // if key/ca/cert was passed in, check if connection is authorized
-          if (typeof(self.ssl) != 'boolean' && !self.sock.authorized) {
-            self.close(true);
-            caller(callback, SMTPError('could not establish an ssl connection', SMTPError.CONNECTIONAUTH, err));
-          } else self._secure = true;
+          if (typeof(this.ssl) != 'boolean' && !this.sock.authorized) {
+						this.close(true);
+						const msg = 'could not establish an ssl connection';
+            caller(callback, SMTPError(msg, SMTPError.CONNECTIONAUTH, err));
+          } else {
+						this._secure = true;
+					}
         }
       } else {
-        self.close(true);
-        caller(callback, SMTPError("could not connect", SMTPError.COULDNOTCONNECT, err));
+        this.close(true);
+        caller(callback, SMTPError('could not connect', SMTPError.COULDNOTCONNECT, err));
       }
     };
 
-    var response = function(err, msg) {
+    const response = (err, msg) => {
       if (err) {
-        if (self._state === SMTPState.NOTCONNECTED && !self.sock) {
+        if (this._state === SMTPState.NOTCONNECTED && !this.sock) {
           return;
         }
-        self.close(true);
+        this.close(true);
         caller(callback, err);
       } else if (msg.code == '220') {
         log(msg.data);
 
         // might happen first, so no need to wait on connected()
-        self._state = SMTPState.CONNECTED;
+        this._state = SMTPState.CONNECTED;
         caller(callback, null, msg.data);
       } else {
-        log("response (data): " + msg.data);
-        self.quit(function() {
-          caller(callback, SMTPError("bad response on connection", SMTPError.BADRESPONSE, err, msg.data));
+        log(`response (data): ${msg.data}`);
+        this.quit(() => {
+					const err = SMTPError('bad response on connection', SMTPError.BADRESPONSE, err, msg.data);
+          caller(callback, err);
         });
       }
     };
 
-    self._state = SMTPState.CONNECTING;
-    log("connecting: " + self.host + ":" + self.port);
+    this._state = SMTPState.CONNECTING;
+    log(`connecting: ${this.host}:${this.port}`);
 
-    if (self.ssl) {
-      self.sock = tls.connect(self.port, self.host, self.ssl, connected);
+    if (this.ssl) {
+      this.sock = tls.connect(this.port, this.host, this.ssl, connected);
     } else {
-      self.sock = new net.Socket();
-      self.sock.connect(self.port, self.host, connected);
+      this.sock = new net.Socket();
+      this.sock.connect(this.port, this.host, connected);
     }
 
-    self.monitor = SMTPResponse.monitor(self.sock, self.timeout, function() {
-      self.close(true);
-    });
-    self.sock.once('response', response);
-    self.sock.once('error', response); // the socket could reset or throw, so let's handle it and let the user know
-  },
+    this.monitor = SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
+    this.sock.once('response', response);
+    this.sock.once('error', response); // the socket could reset or throw, so let's handle it and let the user know
+  }
 
-  send: function(str, callback) {
-    var self = this;
-
-    if (self.sock && self._state == SMTPState.CONNECTED) {
+  send(str, callback) {
+    if (this.sock && this._state == SMTPState.CONNECTED) {
       log(str);
 
-      var response = function(err, msg) {
+      this.sock.once('response', (err, msg) => {
         if (err) {
           caller(callback, err);
         } else {
           log(msg.data);
           caller(callback, null, msg);
         }
-      };
-
-      self.sock.once('response', response);
-      self.sock.write(str);
+      });
+      this.sock.write(str);
     } else {
-      self.close(true);
+      this.close(true);
       caller(callback, SMTPError('no connection has been established', SMTPError.NOCONNECTION));
     }
-  },
+  }
 
-  command: function(cmd, callback, codes, failed) {
+  command(cmd, callback, codes, failed) {
     codes = Array.isArray(codes) ? codes : typeof(codes) == 'number' ? [codes] : [250];
 
-    var response = function(err, msg) {
+    const response = (err, msg) => {
       if (err) {
         caller(callback, err);
       } else {
         if (codes.indexOf(Number(msg.code)) != -1) {
           caller(callback, err, msg.data, msg.message);
         } else {
-          var errorMessage = "bad response on command '" + cmd.split(' ')[0] + "'";
-          if (msg.message) {
-            errorMessage += ': ' + msg.message;
-          }
+					const suffix = msg.message ? `: ${msg.message}` : '';
+          const errorMessage = `bad response on command '${cmd.split(' ')[0]}'${suffix}`;
           caller(callback, SMTPError(errorMessage, SMTPError.BADRESPONSE, null, msg.data));
         }
       }
     };
 
     this.send(cmd + CRLF, response);
-  },
+  }
 
-  helo: function(callback, domain) {
+  helo(callback, domain) {
     /*
      * SMTP 'helo' command.
      * Hostname to send for self command defaults to the FQDN of the local
      * host.
      */
+    this.command(`helo ${domain || this.domain}`, (err, data) => {
+			if (err) {
+				caller(callback, err);
+			} else {
+				this.parse_smtp_features(data);
+				caller(callback, err, data);
+			}
+		});
+  }
 
-    var self = this,
-
-      response = function(err, data) {
+  starttls(callback) {
+    const response = (err, msg) => {
         if (err) {
-          caller(callback, err);
-        } else {
-          self.parse_smtp_features(data);
-          caller(callback, err, data);
-        }
-      };
-
-    this.command("helo " + (domain || this.domain), response);
-  },
-
-  starttls: function(callback) {
-    var self = this,
-
-      response = function(err, msg) {
-        if (err) {
-          err.message += " while establishing a starttls session";
+          err.message += ' while establishing a starttls session';
           caller(callback, err);
         } else {
           // support new API
           if (tls.TLSSocket) {
-            var secured_socket = new tls.TLSSocket(self.sock, {
-              secureContext: tls.createSecureContext ? tls.createSecureContext(self.tls) : crypto.createCredentials(self.tls),
+            const secured_socket = new tls.TLSSocket(this.sock, {
+              secureContext: tls.createSecureContext ? tls.createSecureContext(this.tls) : crypto.createCredentials(this.tls),
               isServer: false // older versions of node (0.12), do not default to false properly...
             });
 
-            secured_socket.on('error', function(err) {
-              self.close(true);
+            secured_socket.on('error', (err) => {
+              this.close(true);
               caller(callback, err);
             });
 
-            self._secure = true;
-            self.sock = secured_socket;
+            this._secure = true;
+            this.sock = secured_socket;
 
-            SMTPResponse.monitor(self.sock, self.timeout, function() {
-              self.close(true);
-            });
+            SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
             caller(callback, msg.data);
           } else {
-            var secured_socket = null;
-            var secured = function() {
-              self._secure = true;
-              self.sock = secured_socket;
+            const secured_socket = null;
+            const secured = () => {
+              this._secure = true;
+              this.sock = secured_socket;
 
-              var error = function(err) {
-                self.close(true);
-                caller(callback, err);
-              };
-
-              SMTPResponse.monitor(self.sock, self.timeout, function() {
-                self.close(true);
-              });
+              SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
               caller(callback, msg.data);
             };
 
-            //secured_socket = starttls.secure(self.sock, self.tls, secured);
-            var starttls = require('starttls');
+            const starttls = require('starttls');
             secured_socket = starttls({
-              socket: self.sock,
-              host: self.host,
-              port: self.port,
+              socket: this.sock,
+              host: this.host,
+              port: this.port,
               pair: tls.createSecurePair(
-                tls.createSecureContext ? tls.createSecureContext(self.tls) : crypto.createCredentials(self.tls), 
+                tls.createSecureContext ? tls.createSecureContext(this.tls) : crypto.createCredentials(this.tls),
                 false)
             }, secured).cleartext;
 
-            secured_socket.on('error', function(err) {
-              self.close(true);
+            secured_socket.on('error', (err) => {
+              this.close(true);
               caller(callback, err);
             });
           }
         }
       };
 
-    this.command("starttls", response, [220]);
-  },
+    this.command('starttls', response, [220]);
+  }
 
-  parse_smtp_features: function(data) {
-    var self = this;
-
+  parse_smtp_features(data) {
     //  According to RFC1869 some (badly written)
     //  MTA's will disconnect on an ehlo. Toss an exception if
     //  that happens -ddm
 
-    data.split("\n").forEach(function(ext) {
-      var parse = ext.match(/^(?:\d+[\-=]?)\s*?([^\s]+)(?:\s+(.*)\s*?)?$/);
+    data.split('\n').forEach((ext) => {
+      const parse = ext.match(/^(?:\d+[\-=]?)\s*?([^\s]+)(?:\s+(.*)\s*?)?$/);
 
       // To be able to communicate with as many SMTP servers as possible,
       // we have to take the old-style auth advertisement into account,
@@ -321,238 +315,230 @@ SMTP.prototype = {
         // It's actually stricter, in that only spaces are allowed between
         // parameters, but were not going to check for that here.  Note
         // that the space isn't present if there are no parameters.
-        self.features[parse[1].toLowerCase()] = parse[2] || true;
+        this.features[parse[1].toLowerCase()] = parse[2] || true;
       }
     });
 
     return;
-  },
+  }
 
-  ehlo: function(callback, domain) {
-    var self = this,
-
-      response = function(err, data) {
-        if (err) {
-          caller(callback, err);
-        } else {
-          self.parse_smtp_features(data);
-
-          if (self.tls && !self._secure) {
-            self.starttls(function() {
-              self.ehlo(callback, domain);
-            });
-          } else {
-            caller(callback, err, data);
-          }
-        }
-      };
-
+  ehlo(callback, domain) {
     this.features = {};
-    this.command("ehlo " + (domain || this.domain), response);
-  },
+    this.command(`ehlo ${domain || this.domain}`, (err, data) => {
+			if (err) {
+				caller(callback, err);
+			} else {
+				this.parse_smtp_features(data);
 
-  has_extn: function(opt) {
+				if (this.tls && !this._secure) {
+					this.starttls(() => this.ehlo(callback, domain));
+				} else {
+					caller(callback, err, data);
+				}
+			}
+		});
+  }
+
+  has_extn(opt) {
     return this.features[opt.toLowerCase()] === undefined;
-  },
+  }
 
-  help: function(callback, args) {
+  help(callback, args) {
     // SMTP 'help' command, returns text from the server
-    this.command(args ? "help " + args : "help", callback, [211, 214]);
-  },
+    this.command(args ? `help ${args}` : 'help', callback, [211, 214]);
+  }
 
-  rset: function(callback) {
-    this.command("rset", callback);
-  },
+  rset(callback) {
+    this.command('rset', callback);
+  }
 
-  noop: function(callback) {
-    this.send("noop", callback);
-  },
+  noop(callback) {
+    this.send('noop', callback);
+  }
 
-  mail: function(callback, from) {
-    this.command("mail FROM:" + from, callback);
-  },
+  mail(callback, from) {
+    this.command(`mail FROM:${from}`, callback);
+  }
 
-  rcpt: function(callback, to) {
-    this.command("RCPT TO:" + to, callback, [250, 251]);
-  },
+  rcpt(callback, to) {
+    this.command(`RCPT TO:${to}`, callback, [250, 251]);
+  }
 
-  data: function(callback) {
-    this.command("data", callback, [354]);
-  },
+  data(callback) {
+    this.command('data', callback, [354]);
+  }
 
-  data_end: function(callback) {
-    this.command(CRLF + ".", callback);
-  },
+  data_end(callback) {
+    this.command(`${CRLF}.`, callback);
+  }
 
-  message: function(data) {
+  message(data) {
     log(data);
     this.sock.write(data);
-  },
+  }
 
-  verify: function(address, callback) {
-    // SMTP 'verify' command -- checks for address validity."""
-    this.command("vrfy " + address, callback, [250, 251, 252]);
-  },
+  verify(address, callback) {
+    // SMTP 'verify' command -- checks for address validity.
+    this.command(`vrfy ${address}`, callback, [250, 251, 252]);
+  }
 
-  expn: function(address, callback) {
+  expn(address, callback) {
     // SMTP 'expn' command -- expands a mailing list.
-    this.command("expn " + address, callback);
-  },
+    this.command(`expn ${address}`, callback);
+  }
 
-  ehlo_or_helo_if_needed: function(callback, domain) {
-    // Call self.ehlo() and/or self.helo() if needed.                                 
+  ehlo_or_helo_if_needed(callback, domain) {
+    // Call this.ehlo() and/or this.helo() if needed.
     // If there has been no previous EHLO or HELO command self session, self
     //  method tries ESMTP EHLO first.
-    var self = this;
-
     if (!this.features) {
-      var response = function(err, data) {
-        caller(callback, err, data);
-      };
-
-      var attempt = function(err, data) {
-        if (err) self.helo(response, domain);
-        else caller(callback, err, data);
-      };
-
-      self.ehlo(attempt, domain);
-    }
-  },
-
-  login: function(callback, user, password, options) {
-    var self = this,
-
-      login = {
-        user: user ? function() {
-          return user;
-        } : self.user,
-        password: password ? function() {
-          return password;
-        } : self.password,
-        method: options && options.method ? options.method.toUpperCase() : ''
-      },
-
-      domain = options && options.domain ? options.domain : this.domain,
-
-      initiate = function(err, data) {
+      const response = (err, data) => caller(callback, err, data);
+      this.ehlo((err, data) => {
         if (err) {
-          caller(callback, err);
-          return;
-        }
+					this.helo(response, domain);
+				} else {
+					caller(callback, err, data);
+				}
+      }, domain);
+    }
+  }
 
-        /* 
-         * Log in on an SMTP server that requires authentication.
-         *
-         * The arguments are:
-         *     - user:     The user name to authenticate with.
-         *     - password: The password for the authentication.
-         *
-         * If there has been no previous EHLO or HELO command self session, self
-         * method tries ESMTP EHLO first.
-         *
-         * This method will return normally if the authentication was successful.
-         */
+  login(callback, user, password, options) {
+    const login = {
+			user: user ? () => user : this.user,
+			password: password ? () => password : this.password,
+			method: options && options.method ? options.method.toUpperCase() : '',
+		};
 
-        var method = null,
+		const domain = options && options.domain ? options.domain : this.domain;
 
-          encode_cram_md5 = function(challenge) {
-            challenge = (new Buffer(challenge, "base64")).toString("ascii");
+		const initiate = (err, data) => {
+			if (err) {
+				caller(callback, err);
+				return;
+			}
 
-            var hmac = crypto.createHmac('md5', login.password());
-            hmac.update(challenge);
+			/*
+				* Log in on an SMTP server that requires authentication.
+				*
+				* The arguments are:
+				*     - user:     The user name to authenticate with.
+				*     - password: The password for the authentication.
+				*
+				* If there has been no previous EHLO or HELO command self session, self
+				* method tries ESMTP EHLO first.
+				*
+				* This method will return normally if the authentication was successful.
+				*/
 
-            return (new Buffer(login.user() + " " + hmac.digest('hex')).toString("base64"));
-          },
+			let method = null;
 
-          encode_plain = function() {
-            return (new Buffer("\u0000" + login.user() + "\u0000" + login.password())).toString("base64");
-          },
+			const encode_cram_md5 = (challenge) => {
+				const hmac = crypto.createHmac('md5', login.password());
+				hmac.update(Buffer.from(challenge, 'base64').toString('ascii'));
+				return Buffer.from(`${login.user()} ${hmac.digest('hex')}`).toString('base64');
+			};
 
-          encode_xoauth2 = function() {
-            // console.log("user=" + login.user() + "\1auth=Bearer " + login.password()+"\1\1"); 
-            // see: https://developers.google.com/gmail/xoauth2_protocol
-            return (new Buffer("user=" + login.user() + "\u0001auth=Bearer " + login.password() + "\u0001\u0001")).toString("base64");
-          };
+			const encode_plain = () =>
+				Buffer
+					.from(`\u0000${login.user()}\u0000${login.password()}`)
+					.toString('base64');
 
-        // List of authentication methods we support: from preferred to
-        // less preferred methods.
-        if (!method) {
-          var preferred = self.authentication;
-          var auth = "";
+			// see: https://developers.google.com/gmail/xoauth2_protocol
+			const encode_xoauth2 = () =>
+				Buffer
+					.from(`user=${login.user()}\u0001auth=Bearer ${login.password()}\u0001\u0001`)
+					.toString('base64');
 
-          if (self.features && self.features.auth) {
-            if (typeof(self.features.auth) === 'string') {
-              auth = self.features.auth;
-            }
-          }
+			// List of authentication methods we support: from preferred to
+			// less preferred methods.
+			if (!method) {
+				const preferred = this.authentication;
+				let auth = '';
 
-          for (var i = 0; i < preferred.length; i++) {
-            if (auth.indexOf(preferred[i]) != -1) {
-              method = preferred[i];
-              break;
-            }
-          }
-        }
+				if (this.features && this.features.auth) {
+					if (typeof(this.features.auth) === 'string') {
+						auth = this.features.auth;
+					}
+				}
 
-        // handle bad responses from command differently
-        var failed = function(err, data) {
-          self.loggedin = false;
-          self.close(); // if auth is bad, close the connection, it won't get better by itself
-          caller(callback, SMTPError('authorization.failed', SMTPError.AUTHFAILED, err, data));
-        };
+				for (let i = 0; i < preferred.length; i++) {
+					if (auth.includes(preferred[i])) {
+						method = preferred[i];
+						break;
+					}
+				}
+			}
 
-        var response = function(err, data) {
-          if (err) {
-            failed(err, data);
-          } else {
-            self.loggedin = true;
-            caller(callback, err, data);
-          }
-        };
+			// handle bad responses from command differently
+			const failed = (err, data) => {
+				this.loggedin = false;
+				this.close(); // if auth is bad, close the connection, it won't get better by itself
+				caller(callback, SMTPError('authorization.failed', SMTPError.AUTHFAILED, err, data));
+			};
 
-        var attempt = function(err, data, msg) {
-          if (err) {
-            failed(err, data);
-          } else {
-            if (method == AUTH_METHODS.CRAM_MD5) {
-              self.command(encode_cram_md5(msg), response, [235, 503]);
-            } else if (method == AUTH_METHODS.LOGIN) {
-              self.command((new Buffer(login.password())).toString("base64"), response, [235, 503]);
-            }
-          }
-        };
+			const response = (err, data) => {
+				if (err) {
+					failed(err, data);
+				} else {
+					this.loggedin = true;
+					caller(callback, err, data);
+				}
+			};
 
-        var attempt_user = function(err, data, msg) {
-          if (err) {
-            failed(err, data);
-          } else {
-            if (method == AUTH_METHODS.LOGIN) {
-              self.command((new Buffer(login.user())).toString("base64"), attempt, [334]);
-            }
-          }
-        };
+			const attempt = (err, data, msg) => {
+				if (err) {
+					failed(err, data);
+				} else {
+					if (method == AUTH_METHODS.CRAM_MD5) {
+						this.command(encode_cram_md5(msg), response, [235, 503]);
+					} else if (method == AUTH_METHODS.LOGIN) {
+						this.command(Buffer.from(login.password()).toString('base64'), response, [235, 503]);
+					}
+				}
+			};
 
-        if (method == AUTH_METHODS.CRAM_MD5) self.command("AUTH " + AUTH_METHODS.CRAM_MD5, attempt, [334]);
+			const attempt_user = (err, data, msg) => {
+				if (err) {
+					failed(err, data);
+				} else {
+					if (method == AUTH_METHODS.LOGIN) {
+						this.command(Buffer.from(login.user()).toString('base64'), attempt, [334]);
+					}
+				}
+			};
 
-        else if (method == AUTH_METHODS.LOGIN) self.command("AUTH " + AUTH_METHODS.LOGIN, attempt_user, [334]);
+			switch (method) {
+				case AUTH_METHODS.CRAM_MD5:
+					this.command(`AUTH  ${AUTH_METHODS.CRAM_MD5}`, attempt, [334]);
+					break;
+				case AUTH_METHODS.LOGIN:
+					this.command(`AUTH ${AUTH_METHODS.LOGIN}`, attempt_user, [334]);
+					break;
+				case AUTH_METHODS.PLAIN:
+					this.command(`AUTH ${AUTH_METHODS.PLAIN} ${encode_plain(login.user(), login.password())}`, response, [235, 503]);
+					break;
+				case AUTH_METHODS.XOAUTH2:
+					this.command(`AUTH ${AUTH_METHODS.XOAUTH2} ${encode_xoauth2(login.user(), login.password())}`, response, [235, 503]);
+					break;
+				default:
+					const msg = 'no form of authorization supported';
+					const err = SMTPError(msg, SMTPError.AUTHNOTSUPPORTED, null, data);
+					caller(callback, err);
+					break;
+			}
+		};
 
-        else if (method == AUTH_METHODS.PLAIN) self.command("AUTH " + AUTH_METHODS.PLAIN + " " + encode_plain(login.user(), login.password()), response, [235, 503]);
+    this.ehlo_or_helo_if_needed(initiate, domain);
+  }
 
-        else if (method == AUTH_METHODS.XOAUTH2) self.command("AUTH " + AUTH_METHODS.XOAUTH2 + " " + encode_xoauth2(login.user(), login.password()), response, [235, 503]);
-
-        else if (!method) caller(callback, SMTPError('no form of authorization supported', SMTPError.AUTHNOTSUPPORTED, null, data));
-      };
-
-    self.ehlo_or_helo_if_needed(initiate, domain);
-  },
-
-  close: function(force) {
+  close(force) {
     if (this.sock) {
       if (force) {
-        log("smtp connection destroyed!");
+        log('smtp connection destroyed!');
         this.sock.destroy();
       } else {
-        log("smtp connection closed.");
+        log('smtp connection closed.');
         this.sock.end();
       }
     }
@@ -567,21 +553,14 @@ SMTP.prototype = {
     this.sock = null;
     this.features = null;
     this.loggedin = !(this.user() && this.password());
-  },
-
-  quit: function(callback) {
-    var self = this,
-      response = function(err, data) {
-        caller(callback, err, data);
-        self.close();
-      };
-
-    this.command("quit", response, [221, 250]);
   }
-};
 
-for (var each in events.EventEmitter.prototype) {
-  SMTP.prototype[each] = events.EventEmitter.prototype[each];
+  quit(callback) {
+		this.command('quit', (err, data) => {
+			caller(callback, err, data);
+			this.close();
+		}, [221, 250]);
+  }
 }
 
 exports.SMTP = SMTP;

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -120,7 +120,14 @@ class SMTP extends EventEmitter {
 		this.ssl = options.ssl || this.ssl;
 
 		if (this._state != SMTPState.NOTCONNECTED) {
-			this.quit(() => this.connect(callback, port, host, options));
+			this.quit(() =>
+				this.connect(
+					callback,
+					port,
+					host,
+					options
+				)
+			);
 			return;
 		}
 
@@ -178,10 +185,19 @@ class SMTP extends EventEmitter {
 		log(`connecting: ${this.host}:${this.port}`);
 
 		if (this.ssl) {
-			this.sock = tls.connect(this.port, this.host, this.ssl, connected);
+			this.sock = tls.connect(
+				this.port,
+				this.host,
+				this.ssl,
+				connected
+			);
 		} else {
 			this.sock = new net.Socket();
-			this.sock.connect(this.port, this.host, connected);
+			this.sock.connect(
+				this.port,
+				this.host,
+				connected
+			);
 		}
 
 		this.monitor = SMTPResponse.monitor(this.sock, this.timeout, () =>

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -15,44 +15,36 @@ const SMTP_SSL_PORT = 465;
 const SMTP_TLS_PORT = 587;
 const CRLF = '\r\n';
 const AUTH_METHODS = {
-  PLAIN: 'PLAIN',
-  CRAM_MD5: 'CRAM-MD5',
-  LOGIN: 'LOGIN',
-  XOAUTH2: 'XOAUTH2'
+	PLAIN: 'PLAIN',
+	CRAM_MD5: 'CRAM-MD5',
+	LOGIN: 'LOGIN',
+	XOAUTH2: 'XOAUTH2',
 };
 
 const TIMEOUT = 5000;
 let DEBUG = 0;
 
 const log = function() {
-  if (DEBUG) {
-    Array.prototype.slice.call(arguments).forEach(function(d) {
-      console.log(d);
-    });
-  }
-};
-
-const quotedata = function(data) {
-  // Quote data for email.
-  // Double leading '.', and change Unix newline '\\n', or Mac '\\r' into
-  // Internet CRLF end-of-line.
-
-  return data.replace(/(?:\r\n|\n|\r(?!\n))/g, CRLF).replace(/^\./gm, '..');
+	if (DEBUG) {
+		Array.prototype.slice.call(arguments).forEach(function(d) {
+			console.log(d);
+		});
+	}
 };
 
 const caller = function(callback) {
-  if (typeof(callback) == 'function') {
-    const args = Array.prototype.slice.call(arguments);
-    args.shift();
+	if (typeof callback == 'function') {
+		const args = Array.prototype.slice.call(arguments);
+		args.shift();
 
-    callback.apply(null, args);
-  }
+		callback.apply(null, args);
+	}
 };
 
 const SMTPState = {
-  NOTCONNECTED: 0,
-  CONNECTING: 1,
-  CONNECTED: 2
+	NOTCONNECTED: 0,
+	CONNECTING: 1,
+	CONNECTED: 2,
 };
 
 class SMTP extends EventEmitter {
@@ -69,19 +61,22 @@ class SMTP extends EventEmitter {
 			ssl,
 			tls,
 			authentication,
-		} = Object.assign({
-			timeout: TIMEOUT,
-			domain: os.hostname(),
-			host: 'localhost',
-			ssl: false,
-			tls: false,
-			authentication: [
-				AUTH_METHODS.CRAM_MD5,
-				AUTH_METHODS.LOGIN,
-				AUTH_METHODS.PLAIN,
-				AUTH_METHODS.XOAUTH2,
-			],
-		}, options);
+		} = Object.assign(
+			{
+				timeout: TIMEOUT,
+				domain: os.hostname(),
+				host: 'localhost',
+				ssl: false,
+				tls: false,
+				authentication: [
+					AUTH_METHODS.CRAM_MD5,
+					AUTH_METHODS.LOGIN,
+					AUTH_METHODS.PLAIN,
+					AUTH_METHODS.XOAUTH2,
+				],
+			},
+			options
+		);
 
 		this._state = SMTPState.NOTCONNECTED;
 		this._secure = false;
@@ -98,7 +93,7 @@ class SMTP extends EventEmitter {
 		this.tls = tls;
 
 		this.port = port || (ssl ? SMTP_SSL_PORT : tls ? SMTP_TLS_PORT : SMTP_PORT);
-		this.loggedin = (user && password) ? false : true;
+		this.loggedin = user && password ? false : true;
 
 		// keep these strings hidden when quicky debugging/logging
 		this.user = () => options.user;
@@ -106,132 +101,154 @@ class SMTP extends EventEmitter {
 	}
 
 	debug(level) {
-  	DEBUG = level;
-  }
+		DEBUG = level;
+	}
 
-  state() {
-    return this._state;
-  }
+	state() {
+		return this._state;
+	}
 
-  authorized() {
-    return this.loggedin;
-  }
+	authorized() {
+		return this.loggedin;
+	}
 
-  connect(callback, port, host, options) {
-    options = options || {};
+	connect(callback, port, host, options) {
+		options = options || {};
 
-    this.host = host || this.host;
-    this.port = port || this.port;
-    this.ssl = options.ssl || this.ssl;
+		this.host = host || this.host;
+		this.port = port || this.port;
+		this.ssl = options.ssl || this.ssl;
 
-    if (this._state != SMTPState.NOTCONNECTED) {
-      this.quit(() => this.connect(callback, port, host, options));
-      return;
-    }
+		if (this._state != SMTPState.NOTCONNECTED) {
+			this.quit(() => this.connect(callback, port, host, options));
+			return;
+		}
 
-    const connected = (err) => {
-      if (!err) {
-        log(`connected: ${this.host}:${this.port}`);
+		const connected = err => {
+			if (!err) {
+				log(`connected: ${this.host}:${this.port}`);
 
-        if (this.ssl && !this.tls) {
-          // if key/ca/cert was passed in, check if connection is authorized
-          if (typeof(this.ssl) != 'boolean' && !this.sock.authorized) {
+				if (this.ssl && !this.tls) {
+					// if key/ca/cert was passed in, check if connection is authorized
+					if (typeof this.ssl != 'boolean' && !this.sock.authorized) {
 						this.close(true);
 						const msg = 'could not establish an ssl connection';
-            caller(callback, SMTPError(msg, SMTPError.CONNECTIONAUTH, err));
-          } else {
+						caller(callback, SMTPError(msg, SMTPError.CONNECTIONAUTH, err));
+					} else {
 						this._secure = true;
 					}
-        }
-      } else {
-        this.close(true);
-        caller(callback, SMTPError('could not connect', SMTPError.COULDNOTCONNECT, err));
-      }
-    };
+				}
+			} else {
+				this.close(true);
+				caller(
+					callback,
+					SMTPError('could not connect', SMTPError.COULDNOTCONNECT, err)
+				);
+			}
+		};
 
-    const response = (err, msg) => {
-      if (err) {
-        if (this._state === SMTPState.NOTCONNECTED && !this.sock) {
-          return;
-        }
-        this.close(true);
-        caller(callback, err);
-      } else if (msg.code == '220') {
-        log(msg.data);
+		const response = (err, msg) => {
+			if (err) {
+				if (this._state === SMTPState.NOTCONNECTED && !this.sock) {
+					return;
+				}
+				this.close(true);
+				caller(callback, err);
+			} else if (msg.code == '220') {
+				log(msg.data);
 
-        // might happen first, so no need to wait on connected()
-        this._state = SMTPState.CONNECTED;
-        caller(callback, null, msg.data);
-      } else {
-        log(`response (data): ${msg.data}`);
-        this.quit(() => {
-					const err = SMTPError('bad response on connection', SMTPError.BADRESPONSE, err, msg.data);
-          caller(callback, err);
-        });
-      }
-    };
+				// might happen first, so no need to wait on connected()
+				this._state = SMTPState.CONNECTED;
+				caller(callback, null, msg.data);
+			} else {
+				log(`response (data): ${msg.data}`);
+				this.quit(() => {
+					const err = SMTPError(
+						'bad response on connection',
+						SMTPError.BADRESPONSE,
+						err,
+						msg.data
+					);
+					caller(callback, err);
+				});
+			}
+		};
 
-    this._state = SMTPState.CONNECTING;
-    log(`connecting: ${this.host}:${this.port}`);
+		this._state = SMTPState.CONNECTING;
+		log(`connecting: ${this.host}:${this.port}`);
 
-    if (this.ssl) {
-      this.sock = tls.connect(this.port, this.host, this.ssl, connected);
-    } else {
-      this.sock = new net.Socket();
-      this.sock.connect(this.port, this.host, connected);
-    }
+		if (this.ssl) {
+			this.sock = tls.connect(this.port, this.host, this.ssl, connected);
+		} else {
+			this.sock = new net.Socket();
+			this.sock.connect(this.port, this.host, connected);
+		}
 
-    this.monitor = SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
-    this.sock.once('response', response);
-    this.sock.once('error', response); // the socket could reset or throw, so let's handle it and let the user know
-  }
+		this.monitor = SMTPResponse.monitor(this.sock, this.timeout, () =>
+			this.close(true)
+		);
+		this.sock.once('response', response);
+		this.sock.once('error', response); // the socket could reset or throw, so let's handle it and let the user know
+	}
 
-  send(str, callback) {
-    if (this.sock && this._state == SMTPState.CONNECTED) {
-      log(str);
+	send(str, callback) {
+		if (this.sock && this._state == SMTPState.CONNECTED) {
+			log(str);
 
-      this.sock.once('response', (err, msg) => {
-        if (err) {
-          caller(callback, err);
-        } else {
-          log(msg.data);
-          caller(callback, null, msg);
-        }
-      });
-      this.sock.write(str);
-    } else {
-      this.close(true);
-      caller(callback, SMTPError('no connection has been established', SMTPError.NOCONNECTION));
-    }
-  }
+			this.sock.once('response', (err, msg) => {
+				if (err) {
+					caller(callback, err);
+				} else {
+					log(msg.data);
+					caller(callback, null, msg);
+				}
+			});
+			this.sock.write(str);
+		} else {
+			this.close(true);
+			caller(
+				callback,
+				SMTPError('no connection has been established', SMTPError.NOCONNECTION)
+			);
+		}
+	}
 
-  command(cmd, callback, codes, failed) {
-    codes = Array.isArray(codes) ? codes : typeof(codes) == 'number' ? [codes] : [250];
+	command(cmd, callback, codes, failed) {
+		codes = Array.isArray(codes)
+			? codes
+			: typeof codes == 'number'
+				? [codes]
+				: [250];
 
-    const response = (err, msg) => {
-      if (err) {
-        caller(callback, err);
-      } else {
-        if (codes.indexOf(Number(msg.code)) != -1) {
-          caller(callback, err, msg.data, msg.message);
-        } else {
+		const response = (err, msg) => {
+			if (err) {
+				caller(callback, err);
+			} else {
+				if (codes.indexOf(Number(msg.code)) != -1) {
+					caller(callback, err, msg.data, msg.message);
+				} else {
 					const suffix = msg.message ? `: ${msg.message}` : '';
-          const errorMessage = `bad response on command '${cmd.split(' ')[0]}'${suffix}`;
-          caller(callback, SMTPError(errorMessage, SMTPError.BADRESPONSE, null, msg.data));
-        }
-      }
-    };
+					const errorMessage = `bad response on command '${
+						cmd.split(' ')[0]
+					}'${suffix}`;
+					caller(
+						callback,
+						SMTPError(errorMessage, SMTPError.BADRESPONSE, null, msg.data)
+					);
+				}
+			}
+		};
 
-    this.send(cmd + CRLF, response);
-  }
+		this.send(cmd + CRLF, response);
+	}
 
-  helo(callback, domain) {
-    /*
+	helo(callback, domain) {
+		/*
      * SMTP 'helo' command.
      * Hostname to send for self command defaults to the FQDN of the local
      * host.
      */
-    this.command(`helo ${domain || this.domain}`, (err, data) => {
+		this.command(`helo ${domain || this.domain}`, (err, data) => {
 			if (err) {
 				caller(callback, err);
 			} else {
@@ -239,92 +256,102 @@ class SMTP extends EventEmitter {
 				caller(callback, err, data);
 			}
 		});
-  }
+	}
 
-  starttls(callback) {
-    const response = (err, msg) => {
-        if (err) {
-          err.message += ' while establishing a starttls session';
-          caller(callback, err);
-        } else {
-          // support new API
-          if (tls.TLSSocket) {
-            const secured_socket = new tls.TLSSocket(this.sock, {
-              secureContext: tls.createSecureContext ? tls.createSecureContext(this.tls) : crypto.createCredentials(this.tls),
-              isServer: false // older versions of node (0.12), do not default to false properly...
-            });
+	starttls(callback) {
+		const response = (err, msg) => {
+			if (err) {
+				err.message += ' while establishing a starttls session';
+				caller(callback, err);
+			} else {
+				// support new API
+				if (tls.TLSSocket) {
+					const secured_socket = new tls.TLSSocket(this.sock, {
+						secureContext: tls.createSecureContext
+							? tls.createSecureContext(this.tls)
+							: crypto.createCredentials(this.tls),
+						isServer: false, // older versions of node (0.12), do not default to false properly...
+					});
 
-            secured_socket.on('error', (err) => {
-              this.close(true);
-              caller(callback, err);
-            });
+					secured_socket.on('error', err => {
+						this.close(true);
+						caller(callback, err);
+					});
 
-            this._secure = true;
-            this.sock = secured_socket;
+					this._secure = true;
+					this.sock = secured_socket;
 
-            SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
-            caller(callback, msg.data);
-          } else {
-            const secured_socket = null;
-            const secured = () => {
-              this._secure = true;
-              this.sock = secured_socket;
+					SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
+					caller(callback, msg.data);
+				} else {
+					let secured_socket = null;
+					const secured = () => {
+						this._secure = true;
+						this.sock = secured_socket;
 
-              SMTPResponse.monitor(this.sock, this.timeout, () => this.close(true));
-              caller(callback, msg.data);
-            };
+						SMTPResponse.monitor(this.sock, this.timeout, () =>
+							this.close(true)
+						);
+						caller(callback, msg.data);
+					};
 
-            const starttls = require('starttls');
-            secured_socket = starttls({
-              socket: this.sock,
-              host: this.host,
-              port: this.port,
-              pair: tls.createSecurePair(
-                tls.createSecureContext ? tls.createSecureContext(this.tls) : crypto.createCredentials(this.tls),
-                false)
-            }, secured).cleartext;
+					const starttls = require('starttls');
+					secured_socket = starttls(
+						{
+							socket: this.sock,
+							host: this.host,
+							port: this.port,
+							pair: tls.createSecurePair(
+								tls.createSecureContext
+									? tls.createSecureContext(this.tls)
+									: crypto.createCredentials(this.tls),
+								false
+							),
+						},
+						secured
+					).cleartext;
 
-            secured_socket.on('error', (err) => {
-              this.close(true);
-              caller(callback, err);
-            });
-          }
-        }
-      };
+					secured_socket.on('error', err => {
+						this.close(true);
+						caller(callback, err);
+					});
+				}
+			}
+		};
 
-    this.command('starttls', response, [220]);
-  }
+		this.command('starttls', response, [220]);
+	}
 
-  parse_smtp_features(data) {
-    //  According to RFC1869 some (badly written)
-    //  MTA's will disconnect on an ehlo. Toss an exception if
-    //  that happens -ddm
+	parse_smtp_features(data) {
+		//  According to RFC1869 some (badly written)
+		//  MTA's will disconnect on an ehlo. Toss an exception if
+		//  that happens -ddm
 
-    data.split('\n').forEach((ext) => {
-      const parse = ext.match(/^(?:\d+[\-=]?)\s*?([^\s]+)(?:\s+(.*)\s*?)?$/);
+		data.split('\n').forEach(ext => {
+			const parse = ext.match(/^(?:\d+[-=]?)\s*?([^\s]+)(?:\s+(.*)\s*?)?$/);
 
-      // To be able to communicate with as many SMTP servers as possible,
-      // we have to take the old-style auth advertisement into account,
-      // because:
-      // 1) Else our SMTP feature parser gets confused.
-      // 2) There are some servers that only advertise the auth methods we
-      // support using the old style.
+			// To be able to communicate with as many SMTP servers as possible,
+			// we have to take the old-style auth advertisement into account,
+			// because:
+			// 1) Else our SMTP feature parser gets confused.
+			// 2) There are some servers that only advertise the auth methods we
+			// support using the old style.
 
-      if (parse) {
-        // RFC 1869 requires a space between ehlo keyword and parameters.
-        // It's actually stricter, in that only spaces are allowed between
-        // parameters, but were not going to check for that here.  Note
-        // that the space isn't present if there are no parameters.
-        this.features[parse[1].toLowerCase()] = parse[2] || true;
-      }
-    });
+			if (parse) {
+				// RFC 1869 requires a space between ehlo keyword and parameters.
+				// It's actually stricter, in that only spaces are allowed between
+				// parameters, but were not going to check for that here.  Note
+				// that the space isn't present if there are no parameters.
+				this.features[parse[1].toLowerCase()] = parse[2] || true;
+			}
+		});
 
-    return;
-  }
+		return;
+	}
 
-  ehlo(callback, domain) {
-    this.features = {};
-    this.command(`ehlo ${domain || this.domain}`, (err, data) => {
+	ehlo(callback, domain) {
+		this.features = {};
+		this.command(`ehlo ${domain || this.domain}`, (err, data) => {
 			if (err) {
 				caller(callback, err);
 			} else {
@@ -337,74 +364,74 @@ class SMTP extends EventEmitter {
 				}
 			}
 		});
-  }
+	}
 
-  has_extn(opt) {
-    return this.features[opt.toLowerCase()] === undefined;
-  }
+	has_extn(opt) {
+		return this.features[opt.toLowerCase()] === undefined;
+	}
 
-  help(callback, args) {
-    // SMTP 'help' command, returns text from the server
-    this.command(args ? `help ${args}` : 'help', callback, [211, 214]);
-  }
+	help(callback, args) {
+		// SMTP 'help' command, returns text from the server
+		this.command(args ? `help ${args}` : 'help', callback, [211, 214]);
+	}
 
-  rset(callback) {
-    this.command('rset', callback);
-  }
+	rset(callback) {
+		this.command('rset', callback);
+	}
 
-  noop(callback) {
-    this.send('noop', callback);
-  }
+	noop(callback) {
+		this.send('noop', callback);
+	}
 
-  mail(callback, from) {
-    this.command(`mail FROM:${from}`, callback);
-  }
+	mail(callback, from) {
+		this.command(`mail FROM:${from}`, callback);
+	}
 
-  rcpt(callback, to) {
-    this.command(`RCPT TO:${to}`, callback, [250, 251]);
-  }
+	rcpt(callback, to) {
+		this.command(`RCPT TO:${to}`, callback, [250, 251]);
+	}
 
-  data(callback) {
-    this.command('data', callback, [354]);
-  }
+	data(callback) {
+		this.command('data', callback, [354]);
+	}
 
-  data_end(callback) {
-    this.command(`${CRLF}.`, callback);
-  }
+	data_end(callback) {
+		this.command(`${CRLF}.`, callback);
+	}
 
-  message(data) {
-    log(data);
-    this.sock.write(data);
-  }
+	message(data) {
+		log(data);
+		this.sock.write(data);
+	}
 
-  verify(address, callback) {
-    // SMTP 'verify' command -- checks for address validity.
-    this.command(`vrfy ${address}`, callback, [250, 251, 252]);
-  }
+	verify(address, callback) {
+		// SMTP 'verify' command -- checks for address validity.
+		this.command(`vrfy ${address}`, callback, [250, 251, 252]);
+	}
 
-  expn(address, callback) {
-    // SMTP 'expn' command -- expands a mailing list.
-    this.command(`expn ${address}`, callback);
-  }
+	expn(address, callback) {
+		// SMTP 'expn' command -- expands a mailing list.
+		this.command(`expn ${address}`, callback);
+	}
 
-  ehlo_or_helo_if_needed(callback, domain) {
-    // Call this.ehlo() and/or this.helo() if needed.
-    // If there has been no previous EHLO or HELO command self session, self
-    //  method tries ESMTP EHLO first.
-    if (!this.features) {
-      const response = (err, data) => caller(callback, err, data);
-      this.ehlo((err, data) => {
-        if (err) {
+	ehlo_or_helo_if_needed(callback, domain) {
+		// Call this.ehlo() and/or this.helo() if needed.
+		// If there has been no previous EHLO or HELO command self session, self
+		//  method tries ESMTP EHLO first.
+		if (!this.features) {
+			const response = (err, data) => caller(callback, err, data);
+			this.ehlo((err, data) => {
+				if (err) {
 					this.helo(response, domain);
 				} else {
 					caller(callback, err, data);
 				}
-      }, domain);
-    }
-  }
+			}, domain);
+		}
+	}
 
-  login(callback, user, password, options) {
-    const login = {
+	login(callback, user, password, options) {
+		const login = {
 			user: user ? () => user : this.user,
 			password: password ? () => password : this.password,
 			method: options && options.method ? options.method.toUpperCase() : '',
@@ -433,22 +460,24 @@ class SMTP extends EventEmitter {
 
 			let method = null;
 
-			const encode_cram_md5 = (challenge) => {
+			const encode_cram_md5 = challenge => {
 				const hmac = crypto.createHmac('md5', login.password());
 				hmac.update(Buffer.from(challenge, 'base64').toString('ascii'));
-				return Buffer.from(`${login.user()} ${hmac.digest('hex')}`).toString('base64');
+				return Buffer.from(`${login.user()} ${hmac.digest('hex')}`).toString(
+					'base64'
+				);
 			};
 
 			const encode_plain = () =>
-				Buffer
-					.from(`\u0000${login.user()}\u0000${login.password()}`)
-					.toString('base64');
+				Buffer.from(`\u0000${login.user()}\u0000${login.password()}`).toString(
+					'base64'
+				);
 
 			// see: https://developers.google.com/gmail/xoauth2_protocol
 			const encode_xoauth2 = () =>
-				Buffer
-					.from(`user=${login.user()}\u0001auth=Bearer ${login.password()}\u0001\u0001`)
-					.toString('base64');
+				Buffer.from(
+					`user=${login.user()}\u0001auth=Bearer ${login.password()}\u0001\u0001`
+				).toString('base64');
 
 			// List of authentication methods we support: from preferred to
 			// less preferred methods.
@@ -457,7 +486,7 @@ class SMTP extends EventEmitter {
 				let auth = '';
 
 				if (this.features && this.features.auth) {
-					if (typeof(this.features.auth) === 'string') {
+					if (typeof this.features.auth === 'string') {
 						auth = this.features.auth;
 					}
 				}
@@ -474,7 +503,10 @@ class SMTP extends EventEmitter {
 			const failed = (err, data) => {
 				this.loggedin = false;
 				this.close(); // if auth is bad, close the connection, it won't get better by itself
-				caller(callback, SMTPError('authorization.failed', SMTPError.AUTHFAILED, err, data));
+				caller(
+					callback,
+					SMTPError('authorization.failed', SMTPError.AUTHFAILED, err, data)
+				);
 			};
 
 			const response = (err, data) => {
@@ -493,7 +525,11 @@ class SMTP extends EventEmitter {
 					if (method == AUTH_METHODS.CRAM_MD5) {
 						this.command(encode_cram_md5(msg), response, [235, 503]);
 					} else if (method == AUTH_METHODS.LOGIN) {
-						this.command(Buffer.from(login.password()).toString('base64'), response, [235, 503]);
+						this.command(
+							Buffer.from(login.password()).toString('base64'),
+							response,
+							[235, 503]
+						);
 					}
 				}
 			};
@@ -503,7 +539,11 @@ class SMTP extends EventEmitter {
 					failed(err, data);
 				} else {
 					if (method == AUTH_METHODS.LOGIN) {
-						this.command(Buffer.from(login.user()).toString('base64'), attempt, [334]);
+						this.command(
+							Buffer.from(login.user()).toString('base64'),
+							attempt,
+							[334]
+						);
 					}
 				}
 			};
@@ -516,10 +556,24 @@ class SMTP extends EventEmitter {
 					this.command(`AUTH ${AUTH_METHODS.LOGIN}`, attempt_user, [334]);
 					break;
 				case AUTH_METHODS.PLAIN:
-					this.command(`AUTH ${AUTH_METHODS.PLAIN} ${encode_plain(login.user(), login.password())}`, response, [235, 503]);
+					this.command(
+						`AUTH ${AUTH_METHODS.PLAIN} ${encode_plain(
+							login.user(),
+							login.password()
+						)}`,
+						response,
+						[235, 503]
+					);
 					break;
 				case AUTH_METHODS.XOAUTH2:
-					this.command(`AUTH ${AUTH_METHODS.XOAUTH2} ${encode_xoauth2(login.user(), login.password())}`, response, [235, 503]);
+					this.command(
+						`AUTH ${AUTH_METHODS.XOAUTH2} ${encode_xoauth2(
+							login.user(),
+							login.password()
+						)}`,
+						response,
+						[235, 503]
+					);
 					break;
 				default:
 					const msg = 'no form of authorization supported';
@@ -529,38 +583,42 @@ class SMTP extends EventEmitter {
 			}
 		};
 
-    this.ehlo_or_helo_if_needed(initiate, domain);
-  }
+		this.ehlo_or_helo_if_needed(initiate, domain);
+	}
 
-  close(force) {
-    if (this.sock) {
-      if (force) {
-        log('smtp connection destroyed!');
-        this.sock.destroy();
-      } else {
-        log('smtp connection closed.');
-        this.sock.end();
-      }
-    }
+	close(force) {
+		if (this.sock) {
+			if (force) {
+				log('smtp connection destroyed!');
+				this.sock.destroy();
+			} else {
+				log('smtp connection closed.');
+				this.sock.end();
+			}
+		}
 
-    if (this.monitor) {
-      this.monitor.stop();
-      this.monitor = null;
-    }
+		if (this.monitor) {
+			this.monitor.stop();
+			this.monitor = null;
+		}
 
-    this._state = SMTPState.NOTCONNECTED;
-    this._secure = false;
-    this.sock = null;
-    this.features = null;
-    this.loggedin = !(this.user() && this.password());
-  }
+		this._state = SMTPState.NOTCONNECTED;
+		this._secure = false;
+		this.sock = null;
+		this.features = null;
+		this.loggedin = !(this.user() && this.password());
+	}
 
-  quit(callback) {
-		this.command('quit', (err, data) => {
-			caller(callback, err, data);
-			this.close();
-		}, [221, 250]);
-  }
+	quit(callback) {
+		this.command(
+			'quit',
+			(err, data) => {
+				caller(callback, err, data);
+				this.close();
+			},
+			[221, 250]
+		);
+	}
 }
 
 exports.SMTP = SMTP;

--- a/test/authplain.js
+++ b/test/authplain.js
@@ -1,64 +1,64 @@
 describe('authorize plain', function() {
-  const { simpleParser: parser } = require('mailparser');
-  const { SMTPServer: smtpServer } = require('smtp-server');
-  const { expect } = require('chai');
-  const email = require('../email');
+	const { simpleParser: parser } = require('mailparser');
+	const { SMTPServer: smtpServer } = require('smtp-server');
+	const { expect } = require('chai');
+	const email = require('../email');
 	const port = 2526;
 
-  let server = null;
-  let smtp = null;
+	let server = null;
+	let smtp = null;
 
-  const send = function(message, verify, done) {
-    smtp.onData = function(stream, session, callback) {
-      parser(stream)
-        .then(verify)
-        .then(done)
-        .catch(done);
-      stream.on('end', callback);
-    };
-
-    server.send(message, function(err) {
-      if (err) throw err;
-    });
-  };
-
-  before(function(done) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
-
-    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
-    smtp.listen(port, function() {
-      smtp.onAuth = function(auth, session, callback) {
-        if (auth.username == 'pooh' && auth.password == 'honey') {
-          callback(null, { user: 'pooh' });
-        } else {
-          return callback(new Error('invalid user / pass'));
-        }
-      };
-
-      server = email.server.connect({
-        port: port,
-        user: 'pooh',
-        password: 'honey',
-        ssl: true
-			});
-
-      done();
-    });
-  });
-
-  after(function(done) {
-    smtp.close(done);
-  });
-
-  it('login', function(done) {
-		const message = {
-      subject: 'this is a test TEXT message from emailjs',
-      from: 'piglet@gmail.com',
-      to: 'pooh@gmail.com',
-      text: 'It is hard to be brave when you\'re only a Very Small Animal.'
+	const send = function(message, verify, done) {
+		smtp.onData = function(stream, session, callback) {
+			parser(stream)
+				.then(verify)
+				.then(done)
+				.catch(done);
+			stream.on('end', callback);
 		};
 
-    const created = email.message.create(message);
+		server.send(message, function(err) {
+			if (err) throw err;
+		});
+	};
+
+	before(function(done) {
+		process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+
+		smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+		smtp.listen(port, function() {
+			smtp.onAuth = function(auth, session, callback) {
+				if (auth.username == 'pooh' && auth.password == 'honey') {
+					callback(null, { user: 'pooh' });
+				} else {
+					return callback(new Error('invalid user / pass'));
+				}
+			};
+
+			server = email.server.connect({
+				port: port,
+				user: 'pooh',
+				password: 'honey',
+				ssl: true,
+			});
+
+			done();
+		});
+	});
+
+	after(function(done) {
+		smtp.close(done);
+	});
+
+	it('login', function(done) {
+		const message = {
+			subject: 'this is a test TEXT message from emailjs',
+			from: 'piglet@gmail.com',
+			to: 'pooh@gmail.com',
+			text: "It is hard to be brave when you're only a Very Small Animal.",
+		};
+
+		const created = email.message.create(message);
 
 		const callback = function(mail) {
 			expect(mail.text).to.equal(message.text + '\n\n\n');
@@ -67,6 +67,6 @@ describe('authorize plain', function() {
 			expect(mail.to.text).to.equal(message.to);
 		};
 
-    send(created, callback, done);
-  });
+		send(created, callback, done);
+	});
 });

--- a/test/authplain.js
+++ b/test/authplain.js
@@ -18,7 +18,9 @@ describe('authorize plain', function() {
 		};
 
 		server.send(message, function(err) {
-			if (err) throw err;
+			if (err) {
+				throw err;
+			}
 		});
 	};
 

--- a/test/authplain.js
+++ b/test/authplain.js
@@ -1,60 +1,72 @@
-describe("authorize plain", function() {
-   var parser     = require('mailparser').simpleParser;
-   var smtpServer = require("smtp-server").SMTPServer;
-   var expect     = require("chai").expect;
-   var fs         = require("fs");
-   var os         = require("os");
-   var path       = require('path');
-   var email      = require('../email');
-   var port       = 2526;
-   var server     = null;
-   var smtp       = null;
+describe('authorize plain', function() {
+  const { simpleParser: parser } = require('mailparser');
+  const { SMTPServer: smtpServer } = require('smtp-server');
+  const { expect } = require('chai');
+  const email = require('../email');
+	const port = 2526;
 
-   var send = function(message, verify, done) {
-      smtp.onData = function(stream, session, callback) {
-        parser(stream).then(verify).then(done).catch(done);
-        stream.on('end', callback);
+  let server = null;
+  let smtp = null;
+
+  const send = function(message, verify, done) {
+    smtp.onData = function(stream, session, callback) {
+      parser(stream)
+        .then(verify)
+        .then(done)
+        .catch(done);
+      stream.on('end', callback);
+    };
+
+    server.send(message, function(err) {
+      if (err) throw err;
+    });
+  };
+
+  before(function(done) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+
+    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+    smtp.listen(port, function() {
+      smtp.onAuth = function(auth, session, callback) {
+        if (auth.username == 'pooh' && auth.password == 'honey') {
+          callback(null, { user: 'pooh' });
+        } else {
+          return callback(new Error('invalid user / pass'));
+        }
       };
 
-      server.send(message, function(err) { if (err) throw err; });
-   }
+      server = email.server.connect({
+        port: port,
+        user: 'pooh',
+        password: 'honey',
+        ssl: true
+			});
 
-   before(function(done) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+      done();
+    });
+  });
 
-      smtp = new smtpServer({secure: true, authMethods: ["LOGIN"]});
-      smtp.listen(port, function() {
-        smtp.onAuth = function(auth, session, callback) {
-  		  	if (auth.username == "pooh" && auth.password == "honey") {
-            callback(null, {user: "pooh"});
-          } else {
-            return callback(new Error("invalid user / pass"));
-          }
-			  }
+  after(function(done) {
+    smtp.close(done);
+  });
 
-        server = email.server.connect({port:port, user:"pooh", password:"honey", ssl:true});
-        done();
-      });
-   });
+  it('login', function(done) {
+		const message = {
+      subject: 'this is a test TEXT message from emailjs',
+      from: 'piglet@gmail.com',
+      to: 'pooh@gmail.com',
+      text: 'It is hard to be brave when you\'re only a Very Small Animal.'
+		};
 
-   after(function(done) {
-      smtp.close(done);
-   });
+    const created = email.message.create(message);
 
-   it("login", function(done) {
-      var message = {
-        subject: "this is a test TEXT message from emailjs",
-        from:    "piglet@gmail.com",
-        to:      "pooh@gmail.com",
-        text:    "It is hard to be brave when you're only a Very Small Animal."
-      };
+		const callback = function(mail) {
+			expect(mail.text).to.equal(message.text + '\n\n\n');
+			expect(mail.subject).to.equal(message.subject);
+			expect(mail.from.text).to.equal(message.from);
+			expect(mail.to.text).to.equal(message.to);
+		};
 
-      send(email.message.create(message), function(mail) {
-         expect(mail.text).to.equal(message.text + "\n\n\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
-
+    send(created, callback, done);
+  });
 });

--- a/test/authssl.js
+++ b/test/authssl.js
@@ -18,7 +18,9 @@ describe('authorize ssl', function() {
 		};
 
 		server.send(message, function(err) {
-			if (err) throw err;
+			if (err) {
+				throw err;
+			}
 		});
 	};
 

--- a/test/authssl.js
+++ b/test/authssl.js
@@ -1,71 +1,71 @@
 describe('authorize ssl', function() {
-  const { simpleParser: parser } = require('mailparser');
-  const { SMTPServer: smtpServer } = require('smtp-server');
-  const { expect } = require('chai');
-  const email = require('../email');
+	const { simpleParser: parser } = require('mailparser');
+	const { SMTPServer: smtpServer } = require('smtp-server');
+	const { expect } = require('chai');
+	const email = require('../email');
 	const port = 2526;
 
-  let server = null;
-  let smtp = null;
+	let server = null;
+	let smtp = null;
 
-  const send = function(message, verify, done) {
-    smtp.onData = function(stream, session, callback) {
-      parser(stream)
-        .then(verify)
-        .then(done)
-        .catch(done);
-      stream.on('end', callback);
-    };
+	const send = function(message, verify, done) {
+		smtp.onData = function(stream, session, callback) {
+			parser(stream)
+				.then(verify)
+				.then(done)
+				.catch(done);
+			stream.on('end', callback);
+		};
 
-    server.send(message, function(err) {
-      if (err) throw err;
-    });
-  };
+		server.send(message, function(err) {
+			if (err) throw err;
+		});
+	};
 
-  before(function(done) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+	before(function(done) {
+		process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
 
-    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
-    smtp.listen(port, function() {
-      smtp.onAuth = function(auth, session, callback) {
-        if (auth.username == 'pooh' && auth.password == 'honey') {
-          callback(null, { user: 'pooh' });
-        } else {
-          return callback(new Error('invalid user / pass'));
-        }
-      };
+		smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+		smtp.listen(port, function() {
+			smtp.onAuth = function(auth, session, callback) {
+				if (auth.username == 'pooh' && auth.password == 'honey') {
+					callback(null, { user: 'pooh' });
+				} else {
+					return callback(new Error('invalid user / pass'));
+				}
+			};
 
-      server = email.server.connect({
-        port: port,
-        user: 'pooh',
-        password: 'honey',
-        ssl: true
-      });
-      done();
-    });
-  });
+			server = email.server.connect({
+				port: port,
+				user: 'pooh',
+				password: 'honey',
+				ssl: true,
+			});
+			done();
+		});
+	});
 
-  after(function(done) {
-    smtp.close(done);
-  });
+	after(function(done) {
+		smtp.close(done);
+	});
 
-  it('login', function(done) {
-    const message = {
-      subject: 'this is a test TEXT message from emailjs',
-      from: 'pooh@gmail.com',
-      to: 'rabbit@gmail.com',
-      text: 'hello friend, i hope this message finds you well.'
-    };
+	it('login', function(done) {
+		const message = {
+			subject: 'this is a test TEXT message from emailjs',
+			from: 'pooh@gmail.com',
+			to: 'rabbit@gmail.com',
+			text: 'hello friend, i hope this message finds you well.',
+		};
 
-    send(
-      email.message.create(message),
-      function(mail) {
-        expect(mail.text).to.equal(message.text + '\n\n\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-      },
-      done
-    );
-  });
+		send(
+			email.message.create(message),
+			function(mail) {
+				expect(mail.text).to.equal(message.text + '\n\n\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+			},
+			done
+		);
+	});
 });

--- a/test/authssl.js
+++ b/test/authssl.js
@@ -1,59 +1,71 @@
-describe("authorize ssl", function() {
-   var parser     = require('mailparser').simpleParser;
-   var smtpServer = require('smtp-server').SMTPServer;
-   var expect     = require("chai").expect;
-   var fs         = require("fs");
-   var os         = require("os");
-   var path       = require('path');
-   var email      = require('../email');
-   var port       = 2526;
-   var server     = null;
-   var smtp       = null;
+describe('authorize ssl', function() {
+  const { simpleParser: parser } = require('mailparser');
+  const { SMTPServer: smtpServer } = require('smtp-server');
+  const { expect } = require('chai');
+  const email = require('../email');
+	const port = 2526;
 
-   var send = function(message, verify, done) {
-      smtp.onData = function(stream, session, callback) {
-        parser(stream).then(verify).then(done).catch(done);
-        stream.on('end', callback);
+  let server = null;
+  let smtp = null;
+
+  const send = function(message, verify, done) {
+    smtp.onData = function(stream, session, callback) {
+      parser(stream)
+        .then(verify)
+        .then(done)
+        .catch(done);
+      stream.on('end', callback);
+    };
+
+    server.send(message, function(err) {
+      if (err) throw err;
+    });
+  };
+
+  before(function(done) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+
+    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+    smtp.listen(port, function() {
+      smtp.onAuth = function(auth, session, callback) {
+        if (auth.username == 'pooh' && auth.password == 'honey') {
+          callback(null, { user: 'pooh' });
+        } else {
+          return callback(new Error('invalid user / pass'));
+        }
       };
 
-      server.send(message, function(err) { if (err) throw err; });
-   }
-
-   before(function(done) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
-
-      smtp = new smtpServer({secure: true, authMethods: ["LOGIN"]});
-      smtp.listen(port, function() {
-        smtp.onAuth = function(auth, session, callback) {
-  		  	if (auth.username == "pooh" && auth.password == "honey") {
-            callback(null, {user: "pooh"});
-          } else {
-            return callback(new Error("invalid user / pass"));
-          }
-			  }
-
-        server = email.server.connect({port:port, user:"pooh", password:"honey", ssl:true});
-        done();
+      server = email.server.connect({
+        port: port,
+        user: 'pooh',
+        password: 'honey',
+        ssl: true
       });
-   });
+      done();
+    });
+  });
 
-   after(function(done) {
-      smtp.close(done);
-   });
+  after(function(done) {
+    smtp.close(done);
+  });
 
-   it("login", function(done) {
-      var message = {
-         subject: "this is a test TEXT message from emailjs",
-         from:    "pooh@gmail.com",
-         to:      "rabbit@gmail.com",
-         text:    "hello friend, i hope this message finds you well."
-      };
+  it('login', function(done) {
+    const message = {
+      subject: 'this is a test TEXT message from emailjs',
+      from: 'pooh@gmail.com',
+      to: 'rabbit@gmail.com',
+      text: 'hello friend, i hope this message finds you well.'
+    };
 
-      send(email.message.create(message), function(mail) {
-         expect(mail.text).to.equal(message.text + "\n\n\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
+    send(
+      email.message.create(message),
+      function(mail) {
+        expect(mail.text).to.equal(message.text + '\n\n\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+      },
+      done
+    );
+  });
 });

--- a/test/message.js
+++ b/test/message.js
@@ -1,455 +1,455 @@
 describe('messages', function() {
-  const { simpleParser: parser } = require('mailparser');
-  const { SMTPServer: smtpServer } = require('smtp-server');
-  const { expect } = require('chai');
-  const fs = require('fs');
-  const path = require('path');
-  const email = require('../email');
-  const port = 2526;
+	const { simpleParser: parser } = require('mailparser');
+	const { SMTPServer: smtpServer } = require('smtp-server');
+	const { expect } = require('chai');
+	const fs = require('fs');
+	const path = require('path');
+	const email = require('../email');
+	const port = 2526;
 
-  let server = null;
-  let smtp = null;
+	let server = null;
+	let smtp = null;
 
-  const send = function(message, verify, done) {
-    smtp.onData = function(stream, session, callback) {
-      //stream.pipe(process.stdout);
-      parser(stream)
-        .then(verify)
-        .then(done)
-        .catch(done);
-      stream.on('end', callback);
-    };
+	const send = function(message, verify, done) {
+		smtp.onData = function(stream, session, callback) {
+			//stream.pipe(process.stdout);
+			parser(stream)
+				.then(verify)
+				.then(done)
+				.catch(done);
+			stream.on('end', callback);
+		};
 
-    server.send(message, function(err) {
-      if (err) throw err;
-    });
-  };
+		server.send(message, function(err) {
+			if (err) throw err;
+		});
+	};
 
-  before(function(done) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+	before(function(done) {
+		process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
 
-    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
-    smtp.listen(port, function() {
-      smtp.onAuth = function(auth, session, callback) {
-        if (auth.username == 'pooh' && auth.password == 'honey') {
-          callback(null, { user: 'pooh' });
-        } else {
-          return callback(new Error('invalid user / pass'));
-        }
-      };
+		smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+		smtp.listen(port, function() {
+			smtp.onAuth = function(auth, session, callback) {
+				if (auth.username == 'pooh' && auth.password == 'honey') {
+					callback(null, { user: 'pooh' });
+				} else {
+					return callback(new Error('invalid user / pass'));
+				}
+			};
 
-      server = email.server.connect({
-        port: port,
-        user: 'pooh',
-        password: 'honey',
-        ssl: true
-      });
-      done();
-    });
-  });
+			server = email.server.connect({
+				port: port,
+				user: 'pooh',
+				password: 'honey',
+				ssl: true,
+			});
+			done();
+		});
+	});
 
-  after(function(done) {
-    smtp.close(done);
-  });
+	after(function(done) {
+		smtp.close(done);
+	});
 
-  it('simple text message', function(done) {
-    var message = {
-      subject: 'this is a test TEXT message from emailjs',
-      from: 'zelda@gmail.com',
-      to: 'gannon@gmail.com',
-      text: 'hello friend, i hope this message finds you well.',
-      'message-id': 'this is a special id'
-    };
+	it('simple text message', function(done) {
+		var message = {
+			subject: 'this is a test TEXT message from emailjs',
+			from: 'zelda@gmail.com',
+			to: 'gannon@gmail.com',
+			text: 'hello friend, i hope this message finds you well.',
+			'message-id': 'this is a special id',
+		};
 
-    send(
-      email.message.create(message),
-      function(mail) {
-        expect(mail.text).to.equal(message.text + '\n\n\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-        expect(mail.messageId).to.equal('<' + message['message-id'] + '>');
-      },
-      done
-    );
-  });
+		send(
+			email.message.create(message),
+			function(mail) {
+				expect(mail.text).to.equal(message.text + '\n\n\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+				expect(mail.messageId).to.equal('<' + message['message-id'] + '>');
+			},
+			done
+		);
+	});
 
-  it('null text', function(done) {
-    send(
-      {
-        subject: 'this is a test TEXT message from emailjs',
-        from: 'zelda@gmail.com',
-        to: 'gannon@gmail.com',
-        text: null,
-        'message-id': 'this is a special id'
-      },
-      function(mail) {
-        expect(mail.text).to.equal('\n\n\n');
-      },
-      done
-    );
-  });
+	it('null text', function(done) {
+		send(
+			{
+				subject: 'this is a test TEXT message from emailjs',
+				from: 'zelda@gmail.com',
+				to: 'gannon@gmail.com',
+				text: null,
+				'message-id': 'this is a special id',
+			},
+			function(mail) {
+				expect(mail.text).to.equal('\n\n\n');
+			},
+			done
+		);
+	});
 
-  it('empty text', function(done) {
-    send(
-      {
-        subject: 'this is a test TEXT message from emailjs',
-        from: 'zelda@gmail.com',
-        to: 'gannon@gmail.com',
-        text: '',
-        'message-id': 'this is a special id'
-      },
-      function(mail) {
-        expect(mail.text).to.equal('\n\n\n');
-      },
-      done
-    );
-  });
+	it('empty text', function(done) {
+		send(
+			{
+				subject: 'this is a test TEXT message from emailjs',
+				from: 'zelda@gmail.com',
+				to: 'gannon@gmail.com',
+				text: '',
+				'message-id': 'this is a special id',
+			},
+			function(mail) {
+				expect(mail.text).to.equal('\n\n\n');
+			},
+			done
+		);
+	});
 
-  it('simple unicode text message', function(done) {
-    var message = {
-      subject: 'this ✓ is a test ✓ TEXT message from emailjs',
-      from: 'zelda✓ <zelda@gmail.com>',
-      to: 'gannon✓ <gannon@gmail.com>',
-      text: 'hello ✓ friend, i hope this message finds you well.'
-    };
+	it('simple unicode text message', function(done) {
+		var message = {
+			subject: 'this ✓ is a test ✓ TEXT message from emailjs',
+			from: 'zelda✓ <zelda@gmail.com>',
+			to: 'gannon✓ <gannon@gmail.com>',
+			text: 'hello ✓ friend, i hope this message finds you well.',
+		};
 
-    send(
-      email.message.create(message),
-      function(mail) {
-        expect(mail.text).to.equal(message.text + '\n\n\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-      },
-      done
-    );
-  });
+		send(
+			email.message.create(message),
+			function(mail) {
+				expect(mail.text).to.equal(message.text + '\n\n\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+			},
+			done
+		);
+	});
 
-  it('very large text message', function(done) {
-    this.timeout(20000);
-    // thanks to jart+loberstech for this one!
-    var message = {
-      subject: 'this is a test TEXT message from emailjs',
-      from: 'ninjas@gmail.com',
-      to: 'pirates@gmail.com',
-      text: fs.readFileSync(
-        path.join(__dirname, 'attachments/smtp.txt'),
-        'utf-8'
-      )
-    };
+	it('very large text message', function(done) {
+		this.timeout(20000);
+		// thanks to jart+loberstech for this one!
+		var message = {
+			subject: 'this is a test TEXT message from emailjs',
+			from: 'ninjas@gmail.com',
+			to: 'pirates@gmail.com',
+			text: fs.readFileSync(
+				path.join(__dirname, 'attachments/smtp.txt'),
+				'utf-8'
+			),
+		};
 
-    send(
-      email.message.create(message),
-      function(mail) {
-        expect(mail.text).to.equal(message.text.replace(/\r/g, '') + '\n\n\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-      },
-      done
-    );
-  });
+		send(
+			email.message.create(message),
+			function(mail) {
+				expect(mail.text).to.equal(message.text.replace(/\r/g, '') + '\n\n\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+			},
+			done
+		);
+	});
 
-  it('very large text data', function(done) {
-    this.timeout(10000);
-    var text =
-      '<html><body><pre>' +
-      fs.readFileSync(path.join(__dirname, 'attachments/smtp.txt'), 'utf-8') +
-      '</pre></body></html>';
-    var message = {
-      subject: 'this is a test TEXT+DATA message from emailjs',
-      from: 'lobsters@gmail.com',
-      to: 'lizards@gmail.com',
-      text:
-        'hello friend if you are seeing this, you can not view html emails. it is attached inline.',
-      attachment: { data: text, alternative: true }
-    };
+	it('very large text data', function(done) {
+		this.timeout(10000);
+		var text =
+			'<html><body><pre>' +
+			fs.readFileSync(path.join(__dirname, 'attachments/smtp.txt'), 'utf-8') +
+			'</pre></body></html>';
+		var message = {
+			subject: 'this is a test TEXT+DATA message from emailjs',
+			from: 'lobsters@gmail.com',
+			to: 'lizards@gmail.com',
+			text:
+				'hello friend if you are seeing this, you can not view html emails. it is attached inline.',
+			attachment: { data: text, alternative: true },
+		};
 
-    send(
-      message,
-      function(mail) {
-        expect(mail.html).to.equal(text.replace(/\r/g, ''));
-        expect(mail.text).to.equal(message.text + '\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-      },
-      done
-    );
-  });
+		send(
+			message,
+			function(mail) {
+				expect(mail.html).to.equal(text.replace(/\r/g, ''));
+				expect(mail.text).to.equal(message.text + '\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+			},
+			done
+		);
+	});
 
-  it('html data', function(done) {
-    var html = fs.readFileSync(
-      path.join(__dirname, 'attachments/smtp.html'),
-      'utf-8'
-    );
-    var message = {
-      subject: 'this is a test TEXT+HTML+DATA message from emailjs',
-      from: 'obama@gmail.com',
-      to: 'mitt@gmail.com',
-      attachment: { data: html, alternative: true }
-    };
+	it('html data', function(done) {
+		var html = fs.readFileSync(
+			path.join(__dirname, 'attachments/smtp.html'),
+			'utf-8'
+		);
+		var message = {
+			subject: 'this is a test TEXT+HTML+DATA message from emailjs',
+			from: 'obama@gmail.com',
+			to: 'mitt@gmail.com',
+			attachment: { data: html, alternative: true },
+		};
 
-    send(
-      message,
-      function(mail) {
-        expect(mail.html).to.equal(html.replace(/\r/g, ''));
-        expect(mail.text).to.equal('\n');
-        expect(mail.subject).to.equal(message.subject);
-        expect(mail.from.text).to.equal(message.from);
-        expect(mail.to.text).to.equal(message.to);
-      },
-      done
-    );
-  });
+		send(
+			message,
+			function(mail) {
+				expect(mail.html).to.equal(html.replace(/\r/g, ''));
+				expect(mail.text).to.equal('\n');
+				expect(mail.subject).to.equal(message.subject);
+				expect(mail.from.text).to.equal(message.from);
+				expect(mail.to.text).to.equal(message.to);
+			},
+			done
+		);
+	});
 
-  it('html file', function(done) {
-    var html = fs.readFileSync(
-      path.join(__dirname, 'attachments/smtp.html'),
-      'utf-8'
-    );
-    var headers = {
-      subject: 'this is a test TEXT+HTML+FILE message from emailjs',
-      from: 'thomas@gmail.com',
-      to: 'nikolas@gmail.com',
-      attachment: {
-        path: path.join(__dirname, 'attachments/smtp.html'),
-        alternative: true
-      }
-    };
+	it('html file', function(done) {
+		var html = fs.readFileSync(
+			path.join(__dirname, 'attachments/smtp.html'),
+			'utf-8'
+		);
+		var headers = {
+			subject: 'this is a test TEXT+HTML+FILE message from emailjs',
+			from: 'thomas@gmail.com',
+			to: 'nikolas@gmail.com',
+			attachment: {
+				path: path.join(__dirname, 'attachments/smtp.html'),
+				alternative: true,
+			},
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.html).to.equal(html.replace(/\r/g, ''));
-        expect(mail.text).to.equal('\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.html).to.equal(html.replace(/\r/g, ''));
+				expect(mail.text).to.equal('\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('html with image embed', function(done) {
-    var html = fs.readFileSync(
-      path.join(__dirname, 'attachments/smtp2.html'),
-      'utf-8'
-    );
-    var image = fs.readFileSync(path.join(__dirname, 'attachments/smtp.gif'));
-    var headers = {
-      subject: 'this is a test TEXT+HTML+IMAGE message from emailjs',
-      from: 'ninja@gmail.com',
-      to: 'pirate@gmail.com',
-      attachment: {
-        path: path.join(__dirname, 'attachments/smtp2.html'),
-        alternative: true,
-        related: [
-          {
-            path: path.join(__dirname, 'attachments/smtp.gif'),
-            type: 'image/gif',
-            name: 'smtp-diagram.gif',
-            headers: { 'Content-ID': '<smtp-diagram@local>' }
-          }
-        ]
-      }
-    };
+	it('html with image embed', function(done) {
+		var html = fs.readFileSync(
+			path.join(__dirname, 'attachments/smtp2.html'),
+			'utf-8'
+		);
+		var image = fs.readFileSync(path.join(__dirname, 'attachments/smtp.gif'));
+		var headers = {
+			subject: 'this is a test TEXT+HTML+IMAGE message from emailjs',
+			from: 'ninja@gmail.com',
+			to: 'pirate@gmail.com',
+			attachment: {
+				path: path.join(__dirname, 'attachments/smtp2.html'),
+				alternative: true,
+				related: [
+					{
+						path: path.join(__dirname, 'attachments/smtp.gif'),
+						type: 'image/gif',
+						name: 'smtp-diagram.gif',
+						headers: { 'Content-ID': '<smtp-diagram@local>' },
+					},
+				],
+			},
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.attachments[0].content.toString('base64')).to.equal(
-          image.toString('base64')
-        );
-        expect(mail.html).to.equal(html.replace(/\r/g, ''));
-        expect(mail.text).to.equal('\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.attachments[0].content.toString('base64')).to.equal(
+					image.toString('base64')
+				);
+				expect(mail.html).to.equal(html.replace(/\r/g, ''));
+				expect(mail.text).to.equal('\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('html data and attachment', function(done) {
-    var html = fs.readFileSync(
-      path.join(__dirname, 'attachments/smtp.html'),
-      'utf-8'
-    );
-    var headers = {
-      subject: 'this is a test TEXT+HTML+FILE message from emailjs',
-      from: 'thomas@gmail.com',
-      to: 'nikolas@gmail.com',
-      attachment: [
-        {
-          path: path.join(__dirname, 'attachments/smtp.html'),
-          alternative: true
-        },
-        { path: path.join(__dirname, 'attachments/smtp.gif') }
-      ]
-    };
+	it('html data and attachment', function(done) {
+		var html = fs.readFileSync(
+			path.join(__dirname, 'attachments/smtp.html'),
+			'utf-8'
+		);
+		var headers = {
+			subject: 'this is a test TEXT+HTML+FILE message from emailjs',
+			from: 'thomas@gmail.com',
+			to: 'nikolas@gmail.com',
+			attachment: [
+				{
+					path: path.join(__dirname, 'attachments/smtp.html'),
+					alternative: true,
+				},
+				{ path: path.join(__dirname, 'attachments/smtp.gif') },
+			],
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.html).to.equal(html.replace(/\r/g, ''));
-        expect(mail.text).to.equal('\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.html).to.equal(html.replace(/\r/g, ''));
+				expect(mail.text).to.equal('\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('attachment', function(done) {
-    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
-    var headers = {
-      subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
-      from: 'washing@gmail.com',
-      to: 'lincoln@gmail.com',
-      text: 'hello friend, i hope this message and pdf finds you well.',
-      attachment: {
-        path: path.join(__dirname, 'attachments/smtp.pdf'),
-        type: 'application/pdf',
-        name: 'smtp-info.pdf'
-      }
-    };
+	it('attachment', function(done) {
+		var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+		var headers = {
+			subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
+			from: 'washing@gmail.com',
+			to: 'lincoln@gmail.com',
+			text: 'hello friend, i hope this message and pdf finds you well.',
+			attachment: {
+				path: path.join(__dirname, 'attachments/smtp.pdf'),
+				type: 'application/pdf',
+				name: 'smtp-info.pdf',
+			},
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.attachments[0].content.toString('base64')).to.equal(
-          pdf.toString('base64')
-        );
-        expect(mail.text).to.equal(headers.text + '\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.attachments[0].content.toString('base64')).to.equal(
+					pdf.toString('base64')
+				);
+				expect(mail.text).to.equal(headers.text + '\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('attachment sent with unicode filename', function(done) {
-    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
-    var headers = {
-      subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
-      from: 'washing@gmail.com',
-      to: 'lincoln@gmail.com',
-      text: 'hello friend, i hope this message and pdf finds you well.',
-      attachment: {
-        path: path.join(__dirname, 'attachments/smtp.pdf'),
-        type: 'application/pdf',
-        name: 'smtp-✓-info.pdf'
-      }
-    };
+	it('attachment sent with unicode filename', function(done) {
+		var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+		var headers = {
+			subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
+			from: 'washing@gmail.com',
+			to: 'lincoln@gmail.com',
+			text: 'hello friend, i hope this message and pdf finds you well.',
+			attachment: {
+				path: path.join(__dirname, 'attachments/smtp.pdf'),
+				type: 'application/pdf',
+				name: 'smtp-✓-info.pdf',
+			},
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.attachments[0].content.toString('base64')).to.equal(
-          pdf.toString('base64')
-        );
-        expect(mail.attachments[0].filename).to.equal('smtp-✓-info.pdf');
-        expect(mail.text).to.equal(headers.text + '\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.attachments[0].content.toString('base64')).to.equal(
+					pdf.toString('base64')
+				);
+				expect(mail.attachments[0].filename).to.equal('smtp-✓-info.pdf');
+				expect(mail.text).to.equal(headers.text + '\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('attachments', function(done) {
-    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
-    var tar = fs.readFileSync(
-      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
-    );
-    var headers = {
-      subject: 'this is a test TEXT+2+ATTACHMENTS message from emailjs',
-      from: 'sergey@gmail.com',
-      to: 'jobs@gmail.com',
-      text: 'hello friend, i hope this message and attachments finds you well.',
-      attachment: [
-        {
-          path: path.join(__dirname, 'attachments/smtp.pdf'),
-          type: 'application/pdf',
-          name: 'smtp-info.pdf'
-        },
-        {
-          path: path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz'),
-          type: 'application/tar-gz',
-          name: 'postfix.source.2.8.7.tar.gz'
-        }
-      ]
-    };
+	it('attachments', function(done) {
+		var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+		var tar = fs.readFileSync(
+			path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+		);
+		var headers = {
+			subject: 'this is a test TEXT+2+ATTACHMENTS message from emailjs',
+			from: 'sergey@gmail.com',
+			to: 'jobs@gmail.com',
+			text: 'hello friend, i hope this message and attachments finds you well.',
+			attachment: [
+				{
+					path: path.join(__dirname, 'attachments/smtp.pdf'),
+					type: 'application/pdf',
+					name: 'smtp-info.pdf',
+				},
+				{
+					path: path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz'),
+					type: 'application/tar-gz',
+					name: 'postfix.source.2.8.7.tar.gz',
+				},
+			],
+		};
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.attachments[0].content.toString('base64')).to.equal(
-          pdf.toString('base64')
-        );
-        expect(mail.attachments[1].content.toString('base64')).to.equal(
-          tar.toString('base64')
-        );
-        expect(mail.text).to.equal(headers.text + '\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.attachments[0].content.toString('base64')).to.equal(
+					pdf.toString('base64')
+				);
+				expect(mail.attachments[1].content.toString('base64')).to.equal(
+					tar.toString('base64')
+				);
+				expect(mail.text).to.equal(headers.text + '\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 
-  it('streams', function(done) {
-    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
-    var tar = fs.readFileSync(
-      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
-    );
-    var stream = fs.createReadStream(
-      path.join(__dirname, 'attachments/smtp.pdf')
-    );
-    var stream2 = fs.createReadStream(
-      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
-    );
-    var headers = {
-      subject:
-        'this is a test TEXT+2+STREAMED+ATTACHMENTS message from emailjs',
-      from: 'stanford@gmail.com',
-      to: 'mit@gmail.com',
-      text:
-        'hello friend, i hope this message and streamed attachments finds you well.',
-      attachment: [
-        { stream: stream, type: 'application/pdf', name: 'smtp-info.pdf' },
-        {
-          stream: stream2,
-          type: 'application/x-gzip',
-          name: 'postfix.source.2.8.7.tar.gz'
-        }
-      ]
-    };
+	it('streams', function(done) {
+		var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+		var tar = fs.readFileSync(
+			path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+		);
+		var stream = fs.createReadStream(
+			path.join(__dirname, 'attachments/smtp.pdf')
+		);
+		var stream2 = fs.createReadStream(
+			path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+		);
+		var headers = {
+			subject:
+				'this is a test TEXT+2+STREAMED+ATTACHMENTS message from emailjs',
+			from: 'stanford@gmail.com',
+			to: 'mit@gmail.com',
+			text:
+				'hello friend, i hope this message and streamed attachments finds you well.',
+			attachment: [
+				{ stream: stream, type: 'application/pdf', name: 'smtp-info.pdf' },
+				{
+					stream: stream2,
+					type: 'application/x-gzip',
+					name: 'postfix.source.2.8.7.tar.gz',
+				},
+			],
+		};
 
-    stream.pause();
-    stream2.pause();
+		stream.pause();
+		stream2.pause();
 
-    send(
-      headers,
-      function(mail) {
-        expect(mail.attachments[0].content.toString('base64')).to.equal(
-          pdf.toString('base64')
-        );
-        expect(mail.attachments[1].content.toString('base64')).to.equal(
-          tar.toString('base64')
-        );
-        expect(mail.text).to.equal(headers.text + '\n');
-        expect(mail.subject).to.equal(headers.subject);
-        expect(mail.from.text).to.equal(headers.from);
-        expect(mail.to.text).to.equal(headers.to);
-      },
-      done
-    );
-  });
+		send(
+			headers,
+			function(mail) {
+				expect(mail.attachments[0].content.toString('base64')).to.equal(
+					pdf.toString('base64')
+				);
+				expect(mail.attachments[1].content.toString('base64')).to.equal(
+					tar.toString('base64')
+				);
+				expect(mail.text).to.equal(headers.text + '\n');
+				expect(mail.subject).to.equal(headers.subject);
+				expect(mail.from.text).to.equal(headers.from);
+				expect(mail.to.text).to.equal(headers.to);
+			},
+			done
+		);
+	});
 });

--- a/test/message.js
+++ b/test/message.js
@@ -142,7 +142,7 @@ describe('messages', function() {
     send(
       email.message.create(message),
       function(mail) {
-        expect(mail.text).to.equal(message.text + '\n\n\n');
+        expect(mail.text).to.equal(message.text.replace(/\r/g, '') + '\n\n\n');
         expect(mail.subject).to.equal(message.subject);
         expect(mail.from.text).to.equal(message.from);
         expect(mail.to.text).to.equal(message.to);
@@ -169,7 +169,7 @@ describe('messages', function() {
     send(
       message,
       function(mail) {
-        expect(mail.html).to.equal(text);
+        expect(mail.html).to.equal(text.replace(/\r/g, ''));
         expect(mail.text).to.equal(message.text + '\n');
         expect(mail.subject).to.equal(message.subject);
         expect(mail.from.text).to.equal(message.from);
@@ -194,7 +194,7 @@ describe('messages', function() {
     send(
       message,
       function(mail) {
-        expect(mail.html).to.equal(html);
+        expect(mail.html).to.equal(html.replace(/\r/g, ''));
         expect(mail.text).to.equal('\n');
         expect(mail.subject).to.equal(message.subject);
         expect(mail.from.text).to.equal(message.from);
@@ -222,7 +222,7 @@ describe('messages', function() {
     send(
       headers,
       function(mail) {
-        expect(mail.html).to.equal(html);
+        expect(mail.html).to.equal(html.replace(/\r/g, ''));
         expect(mail.text).to.equal('\n');
         expect(mail.subject).to.equal(headers.subject);
         expect(mail.from.text).to.equal(headers.from);
@@ -262,7 +262,7 @@ describe('messages', function() {
         expect(mail.attachments[0].content.toString('base64')).to.equal(
           image.toString('base64')
         );
-        expect(mail.html).to.equal(html);
+        expect(mail.html).to.equal(html.replace(/\r/g, ''));
         expect(mail.text).to.equal('\n');
         expect(mail.subject).to.equal(headers.subject);
         expect(mail.from.text).to.equal(headers.from);
@@ -293,7 +293,7 @@ describe('messages', function() {
     send(
       headers,
       function(mail) {
-        expect(mail.html).to.equal(html);
+        expect(mail.html).to.equal(html.replace(/\r/g, ''));
         expect(mail.text).to.equal('\n');
         expect(mail.subject).to.equal(headers.subject);
         expect(mail.from.text).to.equal(headers.from);

--- a/test/message.js
+++ b/test/message.js
@@ -21,7 +21,9 @@ describe('messages', function() {
 		};
 
 		server.send(message, function(err) {
-			if (err) throw err;
+			if (err) {
+				throw err;
+			}
 		});
 	};
 

--- a/test/message.js
+++ b/test/message.js
@@ -1,329 +1,455 @@
-describe("messages", function() {
-   var parser     = require('mailparser').simpleParser;
-   var smtpServer = require('smtp-server').SMTPServer;
-   var expect     = require("chai").expect;
-   var fs         = require("fs");
-   var os         = require("os");
-   var path       = require('path');
-   var email      = require('../email');
-   var port       = 2526;
-   var server     = null;
-   var smtp       = null;
+describe('messages', function() {
+  const { simpleParser: parser } = require('mailparser');
+  const { SMTPServer: smtpServer } = require('smtp-server');
+  const { expect } = require('chai');
+  const fs = require('fs');
+  const path = require('path');
+  const email = require('../email');
+  const port = 2526;
 
-   var send = function(message, verify, done) {
-      smtp.onData = function(stream, session, callback) {
-        //stream.pipe(process.stdout);
-        parser(stream).then(verify).then(done).catch(done);
-        stream.on('end', callback);
+  let server = null;
+  let smtp = null;
+
+  const send = function(message, verify, done) {
+    smtp.onData = function(stream, session, callback) {
+      //stream.pipe(process.stdout);
+      parser(stream)
+        .then(verify)
+        .then(done)
+        .catch(done);
+      stream.on('end', callback);
+    };
+
+    server.send(message, function(err) {
+      if (err) throw err;
+    });
+  };
+
+  before(function(done) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
+
+    smtp = new smtpServer({ secure: true, authMethods: ['LOGIN'] });
+    smtp.listen(port, function() {
+      smtp.onAuth = function(auth, session, callback) {
+        if (auth.username == 'pooh' && auth.password == 'honey') {
+          callback(null, { user: 'pooh' });
+        } else {
+          return callback(new Error('invalid user / pass'));
+        }
       };
 
-      server.send(message, function(err) { if (err) throw err; });
-   }
-
-   before(function(done) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // prevent CERT_HAS_EXPIRED errors
-
-      smtp = new smtpServer({secure: true, authMethods: ["LOGIN"]});
-      smtp.listen(port, function() {
-        smtp.onAuth = function(auth, session, callback) {
-  		  	if (auth.username == "pooh" && auth.password == "honey") {
-            callback(null, {user: "pooh"});
-          } else {
-            return callback(new Error("invalid user / pass"));
-          }
-			  }
-
-        server = email.server.connect({port:port, user:"pooh", password:"honey", ssl:true});
-        done();
+      server = email.server.connect({
+        port: port,
+        user: 'pooh',
+        password: 'honey',
+        ssl: true
       });
-   });
+      done();
+    });
+  });
 
-   after(function(done) {
-      smtp.close(done);
-   });
+  after(function(done) {
+    smtp.close(done);
+  });
 
-   it("simple text message", function(done)
-   {
-      var message = {
-         subject: "this is a test TEXT message from emailjs",
-         from:    "zelda@gmail.com",
-         to:      "gannon@gmail.com",
-         text:    "hello friend, i hope this message finds you well.",
-         "message-id": "this is a special id"
-      };
+  it('simple text message', function(done) {
+    var message = {
+      subject: 'this is a test TEXT message from emailjs',
+      from: 'zelda@gmail.com',
+      to: 'gannon@gmail.com',
+      text: 'hello friend, i hope this message finds you well.',
+      'message-id': 'this is a special id'
+    };
 
-      send(email.message.create(message), function(mail) {
-         expect(mail.text).to.equal(message.text + "\n\n\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-         expect(mail.messageId).to.equal('<' + message['message-id'] + '>');
-      }, done);
-   });
+    send(
+      email.message.create(message),
+      function(mail) {
+        expect(mail.text).to.equal(message.text + '\n\n\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+        expect(mail.messageId).to.equal('<' + message['message-id'] + '>');
+      },
+      done
+    );
+  });
 
-   it('null text', function(done) {
-      send({
-         subject: "this is a test TEXT message from emailjs",
-         from:    "zelda@gmail.com",
-         to:      "gannon@gmail.com",
-         text:    null,
-         "message-id": "this is a special id"
-      }, function(mail) {
-         expect(mail.text).to.equal("\n\n\n");
-      }, done);
-   });
-
-   it('empty text', function(done) {
-      send({
-         subject: "this is a test TEXT message from emailjs",
-         from:    "zelda@gmail.com",
-         to:      "gannon@gmail.com",
-         text:    "",
-         "message-id": "this is a special id"
-      }, function(mail) {
-         expect(mail.text).to.equal("\n\n\n");
-      }, done);
-   });
-
-   it("simple unicode text message", function(done)
-   {
-      var message =
+  it('null text', function(done) {
+    send(
       {
-         subject: "this ✓ is a test ✓ TEXT message from emailjs",
-         from:    "zelda✓ <zelda@gmail.com>",
-         to:      "gannon✓ <gannon@gmail.com>",
-         text:    "hello ✓ friend, i hope this message finds you well."
-      };
+        subject: 'this is a test TEXT message from emailjs',
+        from: 'zelda@gmail.com',
+        to: 'gannon@gmail.com',
+        text: null,
+        'message-id': 'this is a special id'
+      },
+      function(mail) {
+        expect(mail.text).to.equal('\n\n\n');
+      },
+      done
+    );
+  });
 
-      send(email.message.create(message), function(mail)
+  it('empty text', function(done) {
+    send(
       {
-         expect(mail.text).to.equal(message.text + "\n\n\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
+        subject: 'this is a test TEXT message from emailjs',
+        from: 'zelda@gmail.com',
+        to: 'gannon@gmail.com',
+        text: '',
+        'message-id': 'this is a special id'
+      },
+      function(mail) {
+        expect(mail.text).to.equal('\n\n\n');
+      },
+      done
+    );
+  });
 
-   it("very large text message", function(done) {
-      this.timeout(20000);
-      // thanks to jart+loberstech for this one!
-      var message = {
-         subject: "this is a test TEXT message from emailjs",
-         from:    "ninjas@gmail.com",
-         to:      "pirates@gmail.com",
-         text:    fs.readFileSync(path.join(__dirname, "attachments/smtp.txt"), "utf-8")
-      };
+  it('simple unicode text message', function(done) {
+    var message = {
+      subject: 'this ✓ is a test ✓ TEXT message from emailjs',
+      from: 'zelda✓ <zelda@gmail.com>',
+      to: 'gannon✓ <gannon@gmail.com>',
+      text: 'hello ✓ friend, i hope this message finds you well.'
+    };
 
-      send(email.message.create(message), function(mail) {
-         expect(mail.text).to.equal(message.text + "\n\n\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
+    send(
+      email.message.create(message),
+      function(mail) {
+        expect(mail.text).to.equal(message.text + '\n\n\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+      },
+      done
+    );
+  });
 
-   it("very large text data", function(done) {
-      this.timeout(10000);
-      var text = "<html><body><pre>" + fs.readFileSync(path.join(__dirname, "attachments/smtp.txt"), "utf-8") + "</pre></body></html>";
-      var message = {
-         subject:    "this is a test TEXT+DATA message from emailjs",
-         from:       "lobsters@gmail.com",
-         to:         "lizards@gmail.com",
-         text:       "hello friend if you are seeing this, you can not view html emails. it is attached inline.",
-         attachment: {data:text, alternative:true}
-      };
+  it('very large text message', function(done) {
+    this.timeout(20000);
+    // thanks to jart+loberstech for this one!
+    var message = {
+      subject: 'this is a test TEXT message from emailjs',
+      from: 'ninjas@gmail.com',
+      to: 'pirates@gmail.com',
+      text: fs.readFileSync(
+        path.join(__dirname, 'attachments/smtp.txt'),
+        'utf-8'
+      )
+    };
 
-      send(message, function(mail) {
-         expect(mail.html).to.equal(text);
-         expect(mail.text).to.equal(message.text + "\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
+    send(
+      email.message.create(message),
+      function(mail) {
+        expect(mail.text).to.equal(message.text + '\n\n\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+      },
+      done
+    );
+  });
 
-   it("html data", function(done) 
-   {
-      var html = fs.readFileSync(path.join(__dirname, "attachments/smtp.html"), "utf-8");
-      var message = {
-         subject:    "this is a test TEXT+HTML+DATA message from emailjs",
-         from:       "obama@gmail.com",
-         to:         "mitt@gmail.com",         
-         attachment: {data:html, alternative:true}
-      };
+  it('very large text data', function(done) {
+    this.timeout(10000);
+    var text =
+      '<html><body><pre>' +
+      fs.readFileSync(path.join(__dirname, 'attachments/smtp.txt'), 'utf-8') +
+      '</pre></body></html>';
+    var message = {
+      subject: 'this is a test TEXT+DATA message from emailjs',
+      from: 'lobsters@gmail.com',
+      to: 'lizards@gmail.com',
+      text:
+        'hello friend if you are seeing this, you can not view html emails. it is attached inline.',
+      attachment: { data: text, alternative: true }
+    };
 
-      send(message, function(mail) {
-         expect(mail.html).to.equal(html);
-         expect(mail.text).to.equal("\n");
-         expect(mail.subject).to.equal(message.subject);
-         expect(mail.from.text).to.equal(message.from);
-         expect(mail.to.text).to.equal(message.to);
-      }, done);
-   });
+    send(
+      message,
+      function(mail) {
+        expect(mail.html).to.equal(text);
+        expect(mail.text).to.equal(message.text + '\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+      },
+      done
+    );
+  });
 
-   it("html file", function(done) {
-      var html    = fs.readFileSync(path.join(__dirname, "attachments/smtp.html"), "utf-8");
-      var headers = {
-         subject: "this is a test TEXT+HTML+FILE message from emailjs",
-         from:    "thomas@gmail.com",
-         to:      "nikolas@gmail.com",
-         attachment: {path:path.join(__dirname, "attachments/smtp.html"), alternative:true}
-      };
+  it('html data', function(done) {
+    var html = fs.readFileSync(
+      path.join(__dirname, 'attachments/smtp.html'),
+      'utf-8'
+    );
+    var message = {
+      subject: 'this is a test TEXT+HTML+DATA message from emailjs',
+      from: 'obama@gmail.com',
+      to: 'mitt@gmail.com',
+      attachment: { data: html, alternative: true }
+    };
 
-      send(headers, function(mail) {
-         expect(mail.html).to.equal(html);
-         expect(mail.text).to.equal("\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+    send(
+      message,
+      function(mail) {
+        expect(mail.html).to.equal(html);
+        expect(mail.text).to.equal('\n');
+        expect(mail.subject).to.equal(message.subject);
+        expect(mail.from.text).to.equal(message.from);
+        expect(mail.to.text).to.equal(message.to);
+      },
+      done
+    );
+  });
 
-   it("html with image embed", function(done) {
-      var html    = fs.readFileSync(path.join(__dirname, "attachments/smtp2.html"), "utf-8");
-      var image   = fs.readFileSync(path.join(__dirname, "attachments/smtp.gif"));
-      var headers = {
-         subject: "this is a test TEXT+HTML+IMAGE message from emailjs",
-         from:    "ninja@gmail.com",
-         to:      "pirate@gmail.com",
-         attachment: {
-            path:          path.join(__dirname, "attachments/smtp2.html"), 
-            alternative:   true,
-            related: [{
-                  path:    path.join(__dirname, "attachments/smtp.gif"),
-                  type:    "image/gif", 
-                  name:    "smtp-diagram.gif", 
-                  headers: {"Content-ID":"<smtp-diagram@local>"}
-               }
-            ]
-         }
-      };
+  it('html file', function(done) {
+    var html = fs.readFileSync(
+      path.join(__dirname, 'attachments/smtp.html'),
+      'utf-8'
+    );
+    var headers = {
+      subject: 'this is a test TEXT+HTML+FILE message from emailjs',
+      from: 'thomas@gmail.com',
+      to: 'nikolas@gmail.com',
+      attachment: {
+        path: path.join(__dirname, 'attachments/smtp.html'),
+        alternative: true
+      }
+    };
 
-      send(headers, function(mail) {
-         expect(mail.attachments[0].content.toString("base64")).to.equal(image.toString("base64"));
-         expect(mail.html).to.equal(html);
-         expect(mail.text).to.equal("\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+    send(
+      headers,
+      function(mail) {
+        expect(mail.html).to.equal(html);
+        expect(mail.text).to.equal('\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-  it("html data and attachment", function(done) {
-		var html    = fs.readFileSync(path.join(__dirname, "attachments/smtp.html"), "utf-8");
-		var headers = {
-				subject: "this is a test TEXT+HTML+FILE message from emailjs",
-				from:    "thomas@gmail.com",
-				to:      "nikolas@gmail.com",
-				attachment: [
-					{path:path.join(__dirname, "attachments/smtp.html"), alternative:true},
-					{path:path.join(__dirname, "attachments/smtp.gif")}
-				]
-			};
+  it('html with image embed', function(done) {
+    var html = fs.readFileSync(
+      path.join(__dirname, 'attachments/smtp2.html'),
+      'utf-8'
+    );
+    var image = fs.readFileSync(path.join(__dirname, 'attachments/smtp.gif'));
+    var headers = {
+      subject: 'this is a test TEXT+HTML+IMAGE message from emailjs',
+      from: 'ninja@gmail.com',
+      to: 'pirate@gmail.com',
+      attachment: {
+        path: path.join(__dirname, 'attachments/smtp2.html'),
+        alternative: true,
+        related: [
+          {
+            path: path.join(__dirname, 'attachments/smtp.gif'),
+            type: 'image/gif',
+            name: 'smtp-diagram.gif',
+            headers: { 'Content-ID': '<smtp-diagram@local>' }
+          }
+        ]
+      }
+    };
 
-		send(headers, function(mail) {
-			expect(mail.html).to.equal(html);
-			expect(mail.text).to.equal("\n");
-			expect(mail.subject).to.equal(headers.subject);
-			expect(mail.from.text).to.equal(headers.from);
-			expect(mail.to.text).to.equal(headers.to);
-		}, done);
-	});
+    send(
+      headers,
+      function(mail) {
+        expect(mail.attachments[0].content.toString('base64')).to.equal(
+          image.toString('base64')
+        );
+        expect(mail.html).to.equal(html);
+        expect(mail.text).to.equal('\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-   it("attachment", function(done)
-   {
-      var pdf     = fs.readFileSync(path.join(__dirname, "attachments/smtp.pdf"));
-      var headers =  {
-         subject: "this is a test TEXT+ATTACHMENT message from emailjs",
-         from:    "washing@gmail.com",
-         to:      "lincoln@gmail.com",
-         text:    "hello friend, i hope this message and pdf finds you well.",
-         attachment:{path:path.join(__dirname, "attachments/smtp.pdf"), type:"application/pdf", name:"smtp-info.pdf"}
-      };
+  it('html data and attachment', function(done) {
+    var html = fs.readFileSync(
+      path.join(__dirname, 'attachments/smtp.html'),
+      'utf-8'
+    );
+    var headers = {
+      subject: 'this is a test TEXT+HTML+FILE message from emailjs',
+      from: 'thomas@gmail.com',
+      to: 'nikolas@gmail.com',
+      attachment: [
+        {
+          path: path.join(__dirname, 'attachments/smtp.html'),
+          alternative: true
+        },
+        { path: path.join(__dirname, 'attachments/smtp.gif') }
+      ]
+    };
 
-      send(headers, function(mail) {
-         expect(mail.attachments[0].content.toString("base64")).to.equal(pdf.toString("base64"));
-         expect(mail.text).to.equal(headers.text + "\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+    send(
+      headers,
+      function(mail) {
+        expect(mail.html).to.equal(html);
+        expect(mail.text).to.equal('\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-   it("attachment sent with unicode filename", function(done) {
-      var pdf     = fs.readFileSync(path.join(__dirname, "attachments/smtp.pdf"));
-      var headers = {
-         subject: "this is a test TEXT+ATTACHMENT message from emailjs",
-         from:    "washing@gmail.com",
-         to:      "lincoln@gmail.com",
-         text:    "hello friend, i hope this message and pdf finds you well.",
-         attachment:{path:path.join(__dirname, "attachments/smtp.pdf"), type:"application/pdf", name:"smtp-✓-info.pdf"}
-      };
+  it('attachment', function(done) {
+    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+    var headers = {
+      subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
+      from: 'washing@gmail.com',
+      to: 'lincoln@gmail.com',
+      text: 'hello friend, i hope this message and pdf finds you well.',
+      attachment: {
+        path: path.join(__dirname, 'attachments/smtp.pdf'),
+        type: 'application/pdf',
+        name: 'smtp-info.pdf'
+      }
+    };
 
-      send(headers, function(mail) {
-         expect(mail.attachments[0].content.toString("base64")).to.equal(pdf.toString("base64"));
-         expect(mail.attachments[0].filename).to.equal("smtp-✓-info.pdf");
-         expect(mail.text).to.equal(headers.text + "\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+    send(
+      headers,
+      function(mail) {
+        expect(mail.attachments[0].content.toString('base64')).to.equal(
+          pdf.toString('base64')
+        );
+        expect(mail.text).to.equal(headers.text + '\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-   it("attachments", function(done)
-   {
-      var pdf     = fs.readFileSync(path.join(__dirname, "attachments/smtp.pdf"));
-      var tar     = fs.readFileSync(path.join(__dirname, "attachments/postfix-2.8.7.tar.gz"));
-      var headers =
-      {
-         subject: "this is a test TEXT+2+ATTACHMENTS message from emailjs",
-         from:    "sergey@gmail.com",
-         to:      "jobs@gmail.com", 
-         text:    "hello friend, i hope this message and attachments finds you well.",
-         attachment:
-         [
-            {path:path.join(__dirname, "attachments/smtp.pdf"), type:"application/pdf", name:"smtp-info.pdf"},
-            {path:path.join(__dirname, "attachments/postfix-2.8.7.tar.gz"), type:"application/tar-gz", name:"postfix.source.2.8.7.tar.gz"}
-         ]
-      };
+  it('attachment sent with unicode filename', function(done) {
+    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+    var headers = {
+      subject: 'this is a test TEXT+ATTACHMENT message from emailjs',
+      from: 'washing@gmail.com',
+      to: 'lincoln@gmail.com',
+      text: 'hello friend, i hope this message and pdf finds you well.',
+      attachment: {
+        path: path.join(__dirname, 'attachments/smtp.pdf'),
+        type: 'application/pdf',
+        name: 'smtp-✓-info.pdf'
+      }
+    };
 
-      send(headers, function(mail) {
-         expect(mail.attachments[0].content.toString("base64")).to.equal(pdf.toString("base64"));
-         expect(mail.attachments[1].content.toString("base64")).to.equal(tar.toString("base64"));
-         expect(mail.text).to.equal(headers.text + "\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+    send(
+      headers,
+      function(mail) {
+        expect(mail.attachments[0].content.toString('base64')).to.equal(
+          pdf.toString('base64')
+        );
+        expect(mail.attachments[0].filename).to.equal('smtp-✓-info.pdf');
+        expect(mail.text).to.equal(headers.text + '\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-   it("streams", function(done) {
-      var pdf     = fs.readFileSync(path.join(__dirname, "attachments/smtp.pdf"));
-      var tar     = fs.readFileSync(path.join(__dirname, "attachments/postfix-2.8.7.tar.gz"));
-      var stream  = fs.createReadStream(path.join(__dirname, "attachments/smtp.pdf"));
-      var stream2 = fs.createReadStream(path.join(__dirname, "attachments/postfix-2.8.7.tar.gz"));
-      var headers = {
-         subject: "this is a test TEXT+2+STREAMED+ATTACHMENTS message from emailjs",
-         from:    "stanford@gmail.com",
-         to:      "mit@gmail.com", 
-         text:    "hello friend, i hope this message and streamed attachments finds you well.",
-         attachment:
-         [
-            {stream:stream, type:"application/pdf", name:"smtp-info.pdf"},
-            {stream:stream2, type:"application/x-gzip", name:"postfix.source.2.8.7.tar.gz"}
-         ]
-      };
+  it('attachments', function(done) {
+    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+    var tar = fs.readFileSync(
+      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+    );
+    var headers = {
+      subject: 'this is a test TEXT+2+ATTACHMENTS message from emailjs',
+      from: 'sergey@gmail.com',
+      to: 'jobs@gmail.com',
+      text: 'hello friend, i hope this message and attachments finds you well.',
+      attachment: [
+        {
+          path: path.join(__dirname, 'attachments/smtp.pdf'),
+          type: 'application/pdf',
+          name: 'smtp-info.pdf'
+        },
+        {
+          path: path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz'),
+          type: 'application/tar-gz',
+          name: 'postfix.source.2.8.7.tar.gz'
+        }
+      ]
+    };
 
-      stream.pause();
-      stream2.pause();
+    send(
+      headers,
+      function(mail) {
+        expect(mail.attachments[0].content.toString('base64')).to.equal(
+          pdf.toString('base64')
+        );
+        expect(mail.attachments[1].content.toString('base64')).to.equal(
+          tar.toString('base64')
+        );
+        expect(mail.text).to.equal(headers.text + '\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 
-      send(headers, function(mail) {
-         expect(mail.attachments[0].content.toString("base64")).to.equal(pdf.toString("base64"));
-         expect(mail.attachments[1].content.toString("base64")).to.equal(tar.toString("base64"));
-         expect(mail.text).to.equal(headers.text + "\n");
-         expect(mail.subject).to.equal(headers.subject);
-         expect(mail.from.text).to.equal(headers.from);
-         expect(mail.to.text).to.equal(headers.to);
-      }, done);
-   });
+  it('streams', function(done) {
+    var pdf = fs.readFileSync(path.join(__dirname, 'attachments/smtp.pdf'));
+    var tar = fs.readFileSync(
+      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+    );
+    var stream = fs.createReadStream(
+      path.join(__dirname, 'attachments/smtp.pdf')
+    );
+    var stream2 = fs.createReadStream(
+      path.join(__dirname, 'attachments/postfix-2.8.7.tar.gz')
+    );
+    var headers = {
+      subject:
+        'this is a test TEXT+2+STREAMED+ATTACHMENTS message from emailjs',
+      from: 'stanford@gmail.com',
+      to: 'mit@gmail.com',
+      text:
+        'hello friend, i hope this message and streamed attachments finds you well.',
+      attachment: [
+        { stream: stream, type: 'application/pdf', name: 'smtp-info.pdf' },
+        {
+          stream: stream2,
+          type: 'application/x-gzip',
+          name: 'postfix.source.2.8.7.tar.gz'
+        }
+      ]
+    };
+
+    stream.pause();
+    stream2.pause();
+
+    send(
+      headers,
+      function(mail) {
+        expect(mail.attachments[0].content.toString('base64')).to.equal(
+          pdf.toString('base64')
+        );
+        expect(mail.attachments[1].content.toString('base64')).to.equal(
+          tar.toString('base64')
+        );
+        expect(mail.text).to.equal(headers.text + '\n');
+        expect(mail.subject).to.equal(headers.subject);
+        expect(mail.from.text).to.equal(headers.from);
+        expect(mail.to.text).to.equal(headers.to);
+      },
+      done
+    );
+  });
 });

--- a/test/server.js
+++ b/test/server.js
@@ -1,9 +1,9 @@
-var path = require('path');
-var assert = require('assert');
+const path = require('path');
+const assert = require('assert');
 
-describe("Connect to wrong email server", function() {
-	var emailModulePath = require.resolve(path.join(__dirname, '..', 'email'));
-	var email;
+describe('Connect to wrong email server', function() {
+	const emailModulePath = require.resolve(path.join(__dirname, '..', 'email'));
+	let email;
 
 	beforeEach(function() {
 		if (require.cache[emailModulePath]) {
@@ -12,14 +12,14 @@ describe("Connect to wrong email server", function() {
 		email = require('../email');
 	});
 
-	it("Should not call callback multiple times with wrong server configuration", function(done) {
+	it('Should not call callback multiple times with wrong server configuration', function(done) {
 		this.timeout(5000);
-		var server = email.server.connect({ host: "bar.baz" });
+		const server = email.server.connect({ host: 'bar.baz' });
 		server.send({
-			from: "foo@bar.baz",
-			to: "foo@bar.baz",
-			subject: "hello world",
-			text: "hello world",
+			from: 'foo@bar.baz',
+			to: 'foo@bar.baz',
+			subject: 'hello world',
+			text: 'hello world',
 		}, function(err) {
 			assert.notEqual(err, null);
 			done();

--- a/test/server.js
+++ b/test/server.js
@@ -15,16 +15,17 @@ describe('Connect to wrong email server', function() {
 	it('Should not call callback multiple times with wrong server configuration', function(done) {
 		this.timeout(5000);
 		const server = email.server.connect({ host: 'bar.baz' });
-		server.send({
-			from: 'foo@bar.baz',
-			to: 'foo@bar.baz',
-			subject: 'hello world',
-			text: 'hello world',
-		}, function(err) {
-			assert.notEqual(err, null);
-			done();
-		});
+		server.send(
+			{
+				from: 'foo@bar.baz',
+				to: 'foo@bar.baz',
+				subject: 'hello world',
+				text: 'hello world',
+			},
+			function(err) {
+				assert.notEqual(err, null);
+				done();
+			}
+		);
 	});
-
 });
-


### PR DESCRIPTION
Hiya!

I'm currently in the process of forking this to run as a serverless function app, mainly by  converting it to an ESM, Rollup-friendly version so I can single-file it up to Azure (Node.js dep management is... not good there). The first thing I did was convert all the code to use ES2015+ features, in the process replacing the deprecated `Buffer` calls with their officially sanctioned alternatives. 

Unsure if the work is wanted upstream, but the tests all pass (on macOS) so I thought I'd at least float it :)

I also removed `iconv` as a dependency since it isn't called anywhere, and won't build on my Windows machine.

Side note: Six tests fail on Windows (`very large text message`, `very large text data`, `html data`, `html file`, `html with image embed` and `html data and attachment`) due to linefeed discrepancies. I didn't change any code to address that, but I thought I'd bring it up. I can go after that in a separate patch if desired.

Thanks & have a nice day! :)