### PR TITLE
add jsdoc types, fix type errors & drop `starttls`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
 				"ignoreRestSiblings": true
 			}
 		],
+		"valid-jsdoc": "error",
     "mocha/handle-done-callback": "error",
     "mocha/no-exclusive-tests": "error",
     "mocha/no-global-tests": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,10 +31,10 @@
 			}
 		],
 		"valid-jsdoc": "error",
-    "mocha/handle-done-callback": "error",
-    "mocha/no-exclusive-tests": "error",
-    "mocha/no-global-tests": "error",
-    "mocha/no-mocha-arrows": "error",
-    "mocha/no-skipped-tests": "error"
+		"mocha/handle-done-callback": "error",
+		"mocha/no-exclusive-tests": "error",
+		"mocha/no-global-tests": "error",
+		"mocha/no-mocha-arrows": "error",
+		"mocha/no-skipped-tests": "error"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "addressparser": "^0.3.2",
-    "emailjs-mime-codec": "^2.0.7",
-    "starttls": "^1.0.1"
+    "emailjs-mime-codec": "^2.0.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -146,8 +146,10 @@ class Client {
 			msg instanceof Message ? msg : canMakeMessage(msg) ? create(msg) : null;
 
 		if (message == null) {
-			// prettier-ignore
-			callback(new Error('message is not a valid Message instance'), /**@type {MessageStack}*/(msg));
+			callback(
+				new Error('message is not a valid Message instance'),
+				/**@type {MessageStack}*/ (msg)
+			);
 			return;
 		}
 
@@ -180,8 +182,7 @@ class Client {
 				this.queue.push(stack);
 				this._poll();
 			} else {
-				// prettier-ignore
-				callback(new Error(why), /**@type {MessageStack}*/(msg));
+				callback(new Error(why), /**@type {MessageStack}*/ (msg));
 			}
 		});
 	}
@@ -248,11 +249,14 @@ class Client {
 	 * @returns {void}
 	 */
 	_sendrcpt(stack) {
-		//prettier-ignore
-		const to = /** @type{Array} */(stack.to).shift().address;
+		if (stack.to == null || typeof stack.to === 'string') {
+			throw new TypeError('stack.to must be array');
+		}
+
+		const to = stack.to.shift().address;
 		this.smtp.rcpt(
 			this._sendsmtp(stack, stack.to.length ? this._sendrcpt : this._senddata),
-			'<' + to + '>'
+			`<${to}>`
 		);
 	}
 

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -128,22 +128,14 @@ class Client {
 	 */
 	send(msg, callback) {
 		/**
-		 * @param {MessageStack} m message stack
-		 * @returns {boolean} can make message
-		 */
-		const canMakeMessage = m => {
-			return (
-				m.from &&
-				(m.to || m.cc || m.bcc) &&
-				(m.text !== undefined || this._containsInlinedHtml(m.attachment))
-			);
-		};
-
-		/**
 		 * @type {Message}
 		 */
 		const message =
-			msg instanceof Message ? msg : canMakeMessage(msg) ? create(msg) : null;
+			msg instanceof Message
+				? msg
+				: this._canMakeMessage(msg)
+					? create(msg)
+					: null;
 
 		if (message == null) {
 			callback(
@@ -185,6 +177,18 @@ class Client {
 				callback(new Error(why), /**@type {MessageStack}*/ (msg));
 			}
 		});
+	}
+
+	/**
+	 * @param {MessageStack} msg message stack
+	 * @returns {boolean} can make message
+	 */
+	_canMakeMessage(msg) {
+		return (
+			msg.from &&
+			(msg.to || msg.cc || msg.bcc) &&
+			(msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
+		);
 	}
 
 	/**

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -146,11 +146,8 @@ class Client {
 
 		message.valid((valid, why) => {
 			if (valid) {
-				/**
-				 * @type {MessageStack}
-				 */
 				const stack = {
-					message: message,
+					message,
 					to: addressparser(message.header.to),
 					from: addressparser(message.header.from)[0].address,
 					callback: (callback || function() {}).bind(this),

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -56,6 +56,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @returns {void}
 	 */
 	_poll() {
@@ -80,6 +81,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @returns {void}
 	 */
@@ -180,6 +182,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} msg message stack
 	 * @returns {boolean} can make message
 	 */
@@ -192,6 +195,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {*} attachment attachment
 	 * @returns {boolean} does contain
 	 */
@@ -206,6 +210,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {*} attachment attachment
 	 * @returns {boolean} is inlined
 	 */
@@ -218,6 +223,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @param {function(MessageStack): void} next next
 	 * @returns {function(Error): void} callback
@@ -239,6 +245,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @returns {void}
 	 */
@@ -249,6 +256,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @returns {void}
 	 */
@@ -265,6 +273,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @returns {void}
 	 */
@@ -273,6 +282,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {MessageStack} stack stack
 	 * @returns {void}
 	 */
@@ -295,6 +305,7 @@ class Client {
 	}
 
 	/**
+	 * @private
 	 * @param {Error} err err
 	 * @param {MessageStack} stack stack
 	 * @returns {void}

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -1,10 +1,10 @@
-const smtp = require('./smtp');
-const message = require('./message');
+const { SMTP, state } = require('./smtp');
+const { Message, create } = require('./message');
 const addressparser = require('addressparser');
 
 class Client {
 	constructor(server) {
-		this.smtp = new smtp.SMTP(server);
+		this.smtp = new SMTP(server);
 		//this.smtp.debug(1);
 
 		this.queue = [];
@@ -17,10 +17,10 @@ class Client {
 		clearTimeout(this.timer);
 
 		if (this.queue.length) {
-			if (this.smtp.state() == smtp.state.NOTCONNECTED) {
+			if (this.smtp.state() == state.NOTCONNECTED) {
 				this._connect(this.queue[0]);
 			} else if (
-				this.smtp.state() == smtp.state.CONNECTED &&
+				this.smtp.state() == state.CONNECTED &&
 				!this.sending &&
 				this.ready
 			) {
@@ -29,7 +29,7 @@ class Client {
 		}
 		// wait around 1 seconds in case something does come in,
 		// otherwise close out SMTP connection if still open
-		else if (this.smtp.state() == smtp.state.CONNECTED) {
+		else if (this.smtp.state() == state.CONNECTED) {
 			this.timer = setTimeout(() => this.smtp.quit(), 1000);
 		}
 	}
@@ -70,15 +70,15 @@ class Client {
 
 	send(msg, callback) {
 		if (
-			!(msg instanceof message.Message) &&
+			!(msg instanceof Message) &&
 			msg.from &&
 			(msg.to || msg.cc || msg.bcc) &&
 			(msg.text !== undefined || this._containsInlinedHtml(msg.attachment))
 		) {
-			msg = message.create(msg);
+			msg = create(msg);
 		}
 
-		if (msg instanceof message.Message) {
+		if (msg instanceof Message) {
 			msg.valid((valid, why) => {
 				if (valid) {
 					const stack = {

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -126,6 +126,10 @@ class Client {
 	 * @returns {void}
 	 */
 	send(msg, callback) {
+		/**
+		 * @param {MessageStack} m message stack
+		 * @returns {boolean} can make message
+		 */
 		const canMakeMessage = m => {
 			return (
 				m.from &&
@@ -133,6 +137,7 @@ class Client {
 				(m.text !== undefined || this._containsInlinedHtml(m.attachment))
 			);
 		};
+
 		/**
 		 * @type {Message}
 		 */

--- a/smtp/client.js
+++ b/smtp/client.js
@@ -318,4 +318,9 @@ class Client {
 }
 
 exports.Client = Client;
+
+/**
+ * @param {SMTPOptions} server smtp options
+ * @returns {Client} the client
+ */
 exports.connect = server => new Client(server);

--- a/smtp/date.js
+++ b/smtp/date.js
@@ -23,7 +23,6 @@ function getRFC2822Date(date = new Date(), useUtc = false) {
 	return dates.join(' ');
 }
 /**
- *
  * @param {Date} [date] an optional date to convert to RFC2822 format (UTC)
  * @returns {string} the converted date
  */

--- a/smtp/date.js
+++ b/smtp/date.js
@@ -1,3 +1,8 @@
+/**
+ * @param {Date} [date] an optional date to convert to RFC2822 format
+ * @param {boolean} [useUtc=false] whether to parse the date as UTC (default: false)
+ * @returns {string} the converted date
+ */
 function getRFC2822Date(date = new Date(), useUtc = false) {
 	if (useUtc) {
 		return getRFC2822DateUTC(date);
@@ -17,7 +22,11 @@ function getRFC2822Date(date = new Date(), useUtc = false) {
 
 	return dates.join(' ');
 }
-
+/**
+ *
+ * @param {Date} [date] an optional date to convert to RFC2822 format (UTC)
+ * @returns {string} the converted date
+ */
 function getRFC2822DateUTC(date = new Date()) {
 	const dates = date.toUTCString().split(' ');
 	dates.pop(); // remove timezone

--- a/smtp/date.js
+++ b/smtp/date.js
@@ -22,6 +22,7 @@ function getRFC2822Date(date = new Date(), useUtc = false) {
 
 	return dates.join(' ');
 }
+
 /**
  * @param {Date} [date] an optional date to convert to RFC2822 format (UTC)
  * @returns {string} the converted date

--- a/smtp/error.js
+++ b/smtp/error.js
@@ -44,13 +44,43 @@ module.exports = function(message, code, error, smtp) {
 	return err;
 };
 
+/**
+ * @type {1}
+ */
 module.exports.COULDNOTCONNECT = 1;
+/**
+ * @type {2}
+ */
 module.exports.BADRESPONSE = 2;
+/**
+ * @type {3}
+ */
 module.exports.AUTHFAILED = 3;
+/**
+ * @type {4}
+ */
 module.exports.TIMEDOUT = 4;
+/**
+ * @type {5}
+ */
 module.exports.ERROR = 5;
+/**
+ * @type {6}
+ */
 module.exports.NOCONNECTION = 6;
+/**
+ * @type {7}
+ */
 module.exports.AUTHNOTSUPPORTED = 7;
+/**
+ * @type {8}
+ */
 module.exports.CONNECTIONCLOSED = 8;
+/**
+ * @type {9}
+ */
 module.exports.CONNECTIONENDED = 9;
+/**
+ * @type {10}
+ */
 module.exports.CONNECTIONAUTH = 10;

--- a/smtp/error.js
+++ b/smtp/error.js
@@ -1,6 +1,37 @@
+class SMTPError extends Error {
+	/**
+	 * @param {string} message the error message
+	 */
+	constructor(message) {
+		super(message);
+
+		/**
+		 * @type {number}
+		 */
+		this.code = null;
+
+		/**
+		 * @type {*}
+		 */
+		this.smtp = null;
+
+		/**
+		 * @type {Error}
+		 */
+		this.previous = null;
+	}
+}
+
+/**
+ * @param {string} message the error message
+ * @param {number} code the error code
+ * @param {Error} [error] an error object
+ * @param {*} [smtp] smtp
+ * @returns {SMTPError} an smtp error object
+ */
 module.exports = function(message, code, error, smtp) {
-	const err = new Error(
-		error && error.message ? `${message} (${error.message})` : message
+	const err = new SMTPError(
+		error != null && error.message ? `${message} (${error.message})` : message
 	);
 
 	err.code = code;

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -208,7 +208,7 @@ class Message {
 	}
 
 	/**
-	 * @param {Function} callback the function to call with the error and buffer
+	 * @param {function(Error, string): void} callback the function to call with the error and buffer
 	 * @returns {void}
 	 */
 	read(callback) {
@@ -298,7 +298,7 @@ class MessageStream extends Stream {
 		 * @param {string} boundary the boundary text between outputs
 		 * @param {MessageAttachment[]} list the list of potential messages to output
 		 * @param {number} index the index of the list item to output
-		 * @param {Function} callback the function to call if index is greater than upper bound
+		 * @param {function(): void} callback the function to call if index is greater than upper bound
 		 * @returns {void}
 		 */
 		const output_message = (boundary, list, index, callback) => {
@@ -354,14 +354,8 @@ class MessageStream extends Stream {
 		};
 
 		/**
-		 * @callback NextFn
-		 * @param {NodeJS.ErrnoException} err
-		 * @returns {void}
-		 */
-
-		/**
 		 * @param {MessageAttachment} attachment the metadata to use as headers
-		 * @param {NextFn} callback the function to call after output is finished
+		 * @param {function(): void} callback the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_attachment = (attachment, callback) => {
@@ -376,7 +370,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {MessageAttachment} attachment the metadata to use as headers
-		 * @param {Function} callback the function to call after output is finished
+		 * @param {function(): void} callback the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_data = (attachment, callback) => {
@@ -390,7 +384,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {MessageAttachment} attachment the metadata to use as headers
-		 * @param {NextFn} next the function to call when the file is closed
+		 * @param {function(NodeJS.ErrnoException): void} next the function to call when the file is closed
 		 * @returns {void}
 		 */
 		const output_file = (attachment, next) => {
@@ -399,7 +393,7 @@ class MessageStream extends Stream {
 			const closed = fd => fs.closeSync(fd);
 
 			/**
-			 * @param {*} err the error to emit
+			 * @param {Error} err the error to emit
 			 * @param {number} fd the file descriptor
 			 * @returns {void}
 			 */
@@ -449,7 +443,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {MessageAttachment} attachment the metadata to use as headers
-		 * @param {Function} callback the function to call after output is finished
+		 * @param {function(): void} callback the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_stream = (attachment, callback) => {
@@ -496,7 +490,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {string} data the data to output as base64
-		 * @param {Function} [callback] the function to call after output is finished
+		 * @param {function(): void} [callback] the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_base64 = (data, callback) => {
@@ -533,7 +527,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {Message} message the message to output
-		 * @param {Function} callback the function to call after output is finished
+		 * @param {function(): void} callback the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_alternative = (message, callback) => {
@@ -561,7 +555,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {MessageAttachment} message the message to output
-		 * @param {Function} callback the function to call after output is finished
+		 * @param {function(): void} callback the function to call after output is finished
 		 * @returns {void}
 		 */
 		const output_related = (message, callback) => {
@@ -618,7 +612,7 @@ class MessageStream extends Stream {
 
 		/**
 		 * @param {string} data the data to output
-		 * @param {Function} [callback] the function
+		 * @param {function(...args): void} [callback] the function
 		 * @param {*[]} [args] array of arguments to pass to the callback
 		 * @returns {void}
 		 */

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -103,13 +103,13 @@ class Message {
 				header === 'attachment' &&
 				typeof headers[header] === 'object'
 			) {
-				const h = headers[header];
-				if (Array.isArray(h)) {
-					for (let i = 0, l = h.length; i < l; i++) {
-						this.attach(h[i]);
+				const attachment = headers[header];
+				if (Array.isArray(attachment)) {
+					for (let i = 0; i < attachment.length; i++) {
+						this.attach(attachment[i]);
 					}
 				} else {
-					this.attach(h);
+					this.attach(attachment);
 				}
 			} else if (header === 'subject') {
 				this.header.subject = mimeWordEncode(headers.subject);

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -470,16 +470,14 @@ class MessageStream extends Stream {
 					let buffer = Buffer.isBuffer(buff) ? buff : Buffer.from(buff);
 
 					if (previous.byteLength > 0) {
-						const buffer2 = Buffer.concat([previous, buffer]);
-						previous = Buffer.alloc(0); // free up the buffer
-						buffer = null; // free up the buffer
-						buffer = buffer2;
+						buffer = Buffer.concat([previous, buffer]);
 					}
 
 					const padded = buffer.length % MIME64CHUNK;
+					previous = Buffer.alloc(padded);
+
 					// encode as much of the buffer to base64 without empty bytes
 					if (padded > 0) {
-						previous = Buffer.alloc(padded);
 						// copy dangling bytes into previous buffer
 						buffer.copy(previous, 0, buffer.length - padded);
 					}

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -257,11 +257,7 @@ class MessageStream extends Stream {
 		const output_file = (attachment, next) => {
 			const chunk = MIME64CHUNK * 16;
 			const buffer = Buffer.alloc(chunk);
-			const closed = fd => {
-				if (fs.closeSync) {
-					fs.closeSync(fd);
-				}
-			};
+			const closed = fd => fs.closeSync(fd);
 
 			const opened = (err, fd) => {
 				if (!err) {

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -9,19 +9,25 @@ const CRLF = '\r\n';
 
 /**
  * MIME standard wants 76 char chunks when sending out.
+ * @type {76}
  */
 const MIMECHUNK = 76;
 
 /**
  * meets both base64 and mime divisibility
+ * @type {456}
  */
-const MIME64CHUNK = MIMECHUNK * 6;
+const MIME64CHUNK = /** @type {456} */ (MIMECHUNK * 6);
 
 /**
  * size of the message stream buffer
+ * @type {12768}
  */
-const BUFFERSIZE = MIMECHUNK * 24 * 7;
+const BUFFERSIZE = /** @type {12768} */ (MIMECHUNK * 24 * 7);
 
+/**
+ * @type {number}
+ */
 let counter = 0;
 
 /**

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -1,7 +1,6 @@
 const { Stream } = require('stream');
 const fs = require('fs');
 const os = require('os');
-const path = require('path');
 const mimeWordEncode = require('emailjs-mime-codec').mimeWordEncode;
 const addressparser = require('addressparser');
 const { getRFC2822Date } = require('./date');
@@ -133,8 +132,7 @@ class Message {
 
 			this.attachments.forEach(attachment => {
 				if (attachment.path) {
-					// migrating path->fs for existsSync)
-					if (!(fs.existsSync || path.existsSync)(attachment.path)) {
+					if (fs.existsSync(attachment.path) == false) {
 						failed.push(`${attachment.path} does not exist`);
 					}
 				} else if (attachment.stream) {

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -1,8 +1,8 @@
-const { Stream } = require('stream');
 const fs = require('fs');
-const os = require('os');
-const mimeWordEncode = require('emailjs-mime-codec').mimeWordEncode;
+const { hostname } = require('os');
+const { Stream } = require('stream');
 const addressparser = require('addressparser');
+const { mimeWordEncode } = require('emailjs-mime-codec');
 const { getRFC2822Date } = require('./date');
 
 const CRLF = '\r\n';
@@ -47,7 +47,7 @@ class Message {
 		this.header = {
 			'message-id': `<${new Date().getTime()}.${counter++}.${
 				process.pid
-			}@${os.hostname()}>`,
+			}@${hostname()}>`,
 			date: getRFC2822Date(),
 		};
 

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -166,15 +166,7 @@ class Message {
 	}
 
 	/**
-	 * This callback is displayed as part of the Requester class.
-	 * @callback validCallback
-	 * @param {boolean} isValid isValid
-	 * @param {string} [message] message
-	 * @returns {void}
-	 */
-
-	/**
-	 * @param {validCallback} callback the function to call with validation info
+	 * @param {function(boolean, string): void} callback This callback is displayed as part of the Requester class.
 	 * @returns {void}
 	 */
 	valid(callback) {
@@ -185,7 +177,7 @@ class Message {
 		if (!(this.header.to || this.header.cc || this.header.bcc)) {
 			callback(false, 'message does not have a valid recipient');
 		} else if (this.attachments.length === 0) {
-			callback(true);
+			callback(true, undefined);
 		} else {
 			const failed = [];
 

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -544,6 +544,9 @@ class MessageStream extends Stream {
 			output_text(message);
 			output(`--${boundary}${CRLF}`);
 
+			/**
+			 * @returns {void}
+			 */
 			const finish = () => {
 				output([CRLF, '--', boundary, '--', CRLF, CRLF].join(''));
 				callback();

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -234,7 +234,7 @@ class Message {
  * @property {string} [charset]
  * @property {string} [method]
  * @property {string} [path]
- * @property {Duplex} [stream]
+ * @property {NodeJS.ReadWriteStream} [stream]
  * @property {boolean} [inline]
  * @property {MessageAttachment} [alternative]
  * @property {MessageAttachment[]} [related]

--- a/smtp/message.js
+++ b/smtp/message.js
@@ -6,12 +6,27 @@ const { mimeWordEncode } = require('emailjs-mime-codec');
 const { getRFC2822Date } = require('./date');
 
 const CRLF = '\r\n';
-const MIMECHUNK = 76; // MIME standard wants 76 char chunks when sending out.
-const MIME64CHUNK = MIMECHUNK * 6; // meets both base64 and mime divisibility
-const BUFFERSIZE = MIMECHUNK * 24 * 7; // size of the message stream buffer
+
+/**
+ * MIME standard wants 76 char chunks when sending out.
+ */
+const MIMECHUNK = 76;
+
+/**
+ * meets both base64 and mime divisibility
+ */
+const MIME64CHUNK = MIMECHUNK * 6;
+
+/**
+ * size of the message stream buffer
+ */
+const BUFFERSIZE = MIMECHUNK * 24 * 7;
 
 let counter = 0;
 
+/**
+ * @returns {string} the generated boundary
+ */
 function generate_boundary() {
 	let text = '';
 	const possible =
@@ -24,6 +39,10 @@ function generate_boundary() {
 	return text;
 }
 
+/**
+ * @param {string} l the person to parse into an address
+ * @returns {string} the parsed address
+ */
 function person2address(l) {
 	return addressparser(l)
 		.map(({ name, address }) => {
@@ -34,6 +53,10 @@ function person2address(l) {
 		.join(', ');
 }
 
+/**
+ * @param {string} header_name the header name to fix
+ * @returns {string} the fixed header name
+ */
 function fix_header_name_case(header_name) {
 	return header_name
 		.toLowerCase()
@@ -41,8 +64,20 @@ function fix_header_name_case(header_name) {
 }
 
 class Message {
+	/**
+	 * @typedef {Object} MessageHeaders
+	 * @property {string?} content-type
+	 * @property {string} [subject]
+	 * @property {string} [text]
+	 * @property {MessageAttachment} [attachment]
+	 * @param {MessageHeaders} headers hash of message headers
+	 */
 	constructor(headers) {
 		this.attachments = [];
+
+		/**
+		 * @type {MessageAttachment}
+		 */
 		this.alternative = null;
 		this.header = {
 			'message-id': `<${new Date().getTime()}.${counter++}.${
@@ -81,11 +116,15 @@ class Message {
 		}
 	}
 
+	/**
+	 * @param {MessageAttachment} options attachment options
+	 * @returns {Message} the current instance for chaining
+	 */
 	attach(options) {
 		/*
-         legacy support, will remove eventually...
-         arguments -> (path, type, name, headers)
-      */
+			legacy support, will remove eventually...
+			arguments -> (path, type, name, headers)
+		*/
 		if (arguments.length > 1) {
 			options = { path: options, type: arguments[1], name: arguments[2] };
 		}
@@ -103,10 +142,13 @@ class Message {
 		return this;
 	}
 
-	/*
-      legacy support, will remove eventually...
-      should use Message.attach() instead
-   */
+	/**
+	 * legacy support, will remove eventually...
+	 * should use Message.attach() instead
+	 * @param {string} html html data
+	 * @param {string} [charset='utf-8'] the charset to encode as
+	 * @returns {Message} the current Message instance
+	 */
 	attach_alternative(html, charset) {
 		this.alternative = {
 			data: html,
@@ -118,6 +160,18 @@ class Message {
 		return this;
 	}
 
+	/**
+	 * This callback is displayed as part of the Requester class.
+	 * @callback validCallback
+	 * @param {boolean} isValid isValid
+	 * @param {string} [message] message
+	 * @returns {void}
+	 */
+
+	/**
+	 * @param {validCallback} callback the function to call with validation info
+	 * @returns {void}
+	 */
 	valid(callback) {
 		if (!this.header.from) {
 			callback(false, 'message does not have a valid sender');
@@ -148,10 +202,18 @@ class Message {
 		}
 	}
 
+	/**
+	 * returns a stream of the current message
+	 * @returns {MessageStream} a stream of the current message
+	 */
 	stream() {
 		return new MessageStream(this);
 	}
 
+	/**
+	 * @param {Function} callback the function to call with the error and buffer
+	 * @returns {void}
+	 */
 	read(callback) {
 		let buffer = '';
 		const str = this.stream();
@@ -161,16 +223,64 @@ class Message {
 	}
 }
 
+/**
+ * @typedef {Object} MessageAttachmentHeaders
+ * @property {string} content-type
+ * @property {string} content-transfer-encoding
+ * @property {string} content-disposition
+ */
+
+/**
+ * @typedef {Object} MessageAttachment
+ * @property {string} [name]
+ * @property {string} [type]
+ * @property {string} [charset]
+ * @property {string} [method]
+ * @property {string} [path]
+ * @property {streams.Duplex} [stream]
+ * @property {boolean} [inline]
+ * @property {MessageAttachment} [alternative]
+ * @property {MessageAttachment[]} [related]
+ * @property {*} [encoded]
+ * @property {*} [data]
+ * @property {MessageAttachmentHeaders} [headers]
+ */
+
 class MessageStream extends Stream {
+	/**
+	 * @param {Message} message the message to stream
+	 */
 	constructor(message) {
 		super();
 
+		/**
+		 * @type {Message}
+		 */
 		this.message = message;
+
+		/**
+		 * @type {boolean}
+		 */
 		this.readable = true;
+
+		/**
+		 * @type {boolean}
+		 */
 		this.paused = false;
+
+		/**
+		 * @type {Buffer}
+		 */
 		this.buffer = Buffer.alloc(MIMECHUNK * 24 * 7);
+
+		/**
+		 * @type {number}
+		 */
 		this.bufferIndex = 0;
 
+		/**
+		 * @returns {void}
+		 */
 		const output_mixed = () => {
 			const boundary = generate_boundary();
 			output(
@@ -187,6 +297,13 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {string} boundary the boundary text between outputs
+		 * @param {MessageAttachment[]} list the list of potential messages to output
+		 * @param {number} index the index of the list item to output
+		 * @param {Function} callback the function to call if index is greater than upper bound
+		 * @returns {void}
+		 */
 		const output_message = (boundary, list, index, callback) => {
 			if (index < list.length) {
 				output(`--${boundary}${CRLF}`);
@@ -205,6 +322,10 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {MessageAttachment} attachment the metadata to use as headers
+		 * @returns {void}
+		 */
 		const output_attachment_headers = attachment => {
 			let data = [];
 			const headers = {
@@ -218,8 +339,8 @@ class MessageStream extends Stream {
 					: `attachment; filename="${mimeWordEncode(attachment.name)}"`,
 			};
 
+			// allow sender to override default headers
 			for (const header in attachment.headers || {}) {
-				// allow sender to override default headers
 				headers[header.toLowerCase()] = attachment.headers[header];
 			}
 
@@ -235,6 +356,17 @@ class MessageStream extends Stream {
 			output(data.concat([CRLF]).join(''));
 		};
 
+		/**
+		 * @callback NextFn
+		 * @param {NodeJS.ErrnoException} err
+		 * @returns {void}
+		 */
+
+		/**
+		 * @param {MessageAttachment} attachment the metadata to use as headers
+		 * @param {NextFn} callback the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_attachment = (attachment, callback) => {
 			const build = attachment.path
 				? output_file
@@ -245,6 +377,11 @@ class MessageStream extends Stream {
 			build(attachment, callback);
 		};
 
+		/**
+		 * @param {MessageAttachment} attachment the metadata to use as headers
+		 * @param {Function} callback the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_data = (attachment, callback) => {
 			output_base64(
 				attachment.encoded
@@ -254,11 +391,21 @@ class MessageStream extends Stream {
 			);
 		};
 
+		/**
+		 * @param {MessageAttachment} attachment the metadata to use as headers
+		 * @param {NextFn} next the function to call when the file is closed
+		 * @returns {void}
+		 */
 		const output_file = (attachment, next) => {
 			const chunk = MIME64CHUNK * 16;
 			const buffer = Buffer.alloc(chunk);
 			const closed = fd => fs.closeSync(fd);
 
+			/**
+			 * @param {*} err the error to emit
+			 * @param {number} fd the file descriptor
+			 * @returns {void}
+			 */
 			const opened = (err, fd) => {
 				if (!err) {
 					const read = (err, bytes) => {
@@ -303,6 +450,11 @@ class MessageStream extends Stream {
 			fs.open(attachment.path, 'r', opened);
 		};
 
+		/**
+		 * @param {MessageAttachment} attachment the metadata to use as headers
+		 * @param {Function} callback the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_stream = (attachment, callback) => {
 			if (attachment.stream.readable) {
 				let previous = null;
@@ -346,6 +498,11 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {string} data the data to output as base64
+		 * @param {Function} [callback] the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_base64 = (data, callback) => {
 			const loops = Math.ceil(data.length / MIMECHUNK);
 			let loop = 0;
@@ -358,6 +515,10 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {Message} message the message to output
+		 * @returns {void}
+		 */
 		const output_text = message => {
 			let data = [];
 
@@ -374,6 +535,11 @@ class MessageStream extends Stream {
 			output(data.join(''));
 		};
 
+		/**
+		 * @param {Message} message the message to output
+		 * @param {Function} callback the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_alternative = (message, callback) => {
 			const boundary = generate_boundary();
 			output(
@@ -394,6 +560,11 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {MessageAttachment} message the message to output
+		 * @param {Function} callback the function to call after output is finished
+		 * @returns {void}
+		 */
 		const output_related = (message, callback) => {
 			const boundary = generate_boundary();
 			output(
@@ -407,6 +578,9 @@ class MessageStream extends Stream {
 			});
 		};
 
+		/**
+		 * @returns {void}
+		 */
 		const output_header_data = () => {
 			if (this.message.attachments.length || this.message.alternative) {
 				output(`MIME-Version: 1.0${CRLF}`);
@@ -418,6 +592,9 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @returns {void}
+		 */
 		const output_header = () => {
 			let data = [];
 
@@ -440,6 +617,12 @@ class MessageStream extends Stream {
 			output_header_data();
 		};
 
+		/**
+		 * @param {string} data the data to output
+		 * @param {Function} [callback] the function
+		 * @param {*[]} [args] array of arguments to pass to the callback
+		 * @returns {void}
+		 */
 		const output = (data, callback, args) => {
 			const bytes = Buffer.byteLength(data);
 
@@ -489,6 +672,10 @@ class MessageStream extends Stream {
 			}
 		};
 
+		/**
+		 * @param {*} [err] the error to emit
+		 * @returns {void}
+		 */
 		const close = err => {
 			if (err) {
 				this.emit('error', err);
@@ -510,16 +697,28 @@ class MessageStream extends Stream {
 		process.nextTick(output_header);
 	}
 
+	/**
+	 * pause the stream
+	 * @returns {void}
+	 */
 	pause() {
 		this.paused = true;
 		this.emit('pause');
 	}
 
+	/**
+	 * resume the stream
+	 * @returns {void}
+	 */
 	resume() {
 		this.paused = false;
 		this.emit('resume');
 	}
 
+	/**
+	 * destroy the stream
+	 * @returns {void}
+	 */
 	destroy() {
 		this.emit(
 			'destroy',
@@ -527,6 +726,10 @@ class MessageStream extends Stream {
 		);
 	}
 
+	/**
+	 * destroy the stream at first opportunity
+	 * @returns {void}
+	 */
 	destroySoon() {
 		this.emit('destroy');
 	}

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -121,6 +121,7 @@ class SMTPResponse {
 		stream.setTimeout(timeout, timedout);
 	}
 }
+
 /**
  * @param {Socket | TLSSocket} stream the open socket to stream a response from
  * @param {number} timeout the time to wait (in milliseconds) before closing the socket

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -1,9 +1,18 @@
 const SMTPError = require('./error');
 
 class SMTPResponse {
+	/**
+	 * @constructor
+	 * @param {Socket | TLSSocket} stream the open socket to stream a response from
+	 * @param {number} timeout the time to wait (in milliseconds) before closing the socket
+	 * @param {Function} onerror the function to call on error
+	 */
 	constructor(stream, timeout, onerror) {
 		let buffer = '';
 
+		/**
+		 * @returns {void}
+		 */
 		const notify = () => {
 			if (buffer.length) {
 				// parse buffer for response codes
@@ -29,6 +38,10 @@ class SMTPResponse {
 			}
 		};
 
+		/**
+		 * @param {Error} err the error object
+		 * @returns {void}
+		 */
 		const error = err => {
 			stream.emit(
 				'response',
@@ -36,6 +49,10 @@ class SMTPResponse {
 			);
 		};
 
+		/**
+		 * @param {Error} err the error object
+		 * @returns {void}
+		 */
 		const timedout = err => {
 			stream.end();
 			stream.emit(
@@ -48,6 +65,10 @@ class SMTPResponse {
 			);
 		};
 
+		/**
+		 * @param {string | Buffer} data the data
+		 * @returns {void}
+		 */
 		const watch = data => {
 			if (data !== null) {
 				buffer += data.toString();
@@ -55,6 +76,10 @@ class SMTPResponse {
 			}
 		};
 
+		/**
+		 * @param {Error} err the error object
+		 * @returns {void}
+		 */
 		const close = err => {
 			stream.emit(
 				'response',
@@ -62,6 +87,10 @@ class SMTPResponse {
 			);
 		};
 
+		/**
+		 * @param {Error} err the error object
+		 * @returns {void}
+		 */
 		const end = err => {
 			stream.emit(
 				'response',
@@ -69,6 +98,10 @@ class SMTPResponse {
 			);
 		};
 
+		/**
+		 * @param {Error} [err] the error object
+		 * @returns {void}
+		 */
 		this.stop = err => {
 			stream.removeAllListeners('response');
 			stream.removeListener('data', watch);
@@ -76,7 +109,7 @@ class SMTPResponse {
 			stream.removeListener('close', close);
 			stream.removeListener('error', error);
 
-			if (err && typeof onerror === 'function') {
+			if (err != null && typeof onerror === 'function') {
 				onerror(err);
 			}
 		};
@@ -88,6 +121,11 @@ class SMTPResponse {
 		stream.setTimeout(timeout, timedout);
 	}
 }
-
+/**
+ * @param {Socket | TLSSocket} stream the open socket to stream a response from
+ * @param {number} timeout the time to wait (in milliseconds) before closing the socket
+ * @param {Function} onerror the function to call on error
+ * @returns {SMTPResponse} the smtp response
+ */
 exports.monitor = (stream, timeout, onerror) =>
 	new SMTPResponse(stream, timeout, onerror);

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -1,10 +1,14 @@
 const SMTPError = require('./error');
-const { TLSSocket } = require('tls');
+
+/**
+ * @typedef {import('net').Socket} Socket
+ * @typedef {import('tls').TLSSocket} TLSSocket
+ */
 
 class SMTPResponse {
 	/**
 	 * @constructor
-	 * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
+	 * @param {Socket | TLSSocket} stream the open socket to stream a response from
 	 * @param {number} timeout the time to wait (in milliseconds) before closing the socket
 	 * @param {function(Error): void} onerror the function to call on error
 	 */
@@ -105,32 +109,28 @@ class SMTPResponse {
 		 */
 		this.stop = err => {
 			stream.removeAllListeners('response');
-			if (stream instanceof TLSSocket) {
-				stream.removeListener('data', watch);
-				stream.removeListener('end', end);
-				stream.removeListener('close', close);
-				stream.removeListener('error', error);
-			}
+			stream.removeListener('data', watch);
+			stream.removeListener('end', end);
+			stream.removeListener('close', close);
+			stream.removeListener('error', error);
 
 			if (err != null && typeof onerror === 'function') {
 				onerror(err);
 			}
 		};
 
-		if (stream instanceof TLSSocket) {
-			stream.on('data', watch);
-			stream.on('end', end);
-			stream.on('close', close);
-			stream.on('error', error);
-			stream.setTimeout(timeout, timedout);
-		}
+		stream.on('data', watch);
+		stream.on('end', end);
+		stream.on('close', close);
+		stream.on('error', error);
+		stream.setTimeout(timeout, timedout);
 	}
 }
 
 exports.SMTPResponse = SMTPResponse;
 
 /**
- * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
+ * @param {Socket | TLSSocket} stream the open socket to stream a response from
  * @param {number} timeout the time to wait (in milliseconds) before closing the socket
  * @param {function(Error): void} onerror the function to call on error
  * @returns {SMTPResponse} the smtp response

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -127,6 +127,8 @@ class SMTPResponse {
 	}
 }
 
+exports.SMTPResponse = SMTPResponse;
+
 /**
  * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
  * @param {number} timeout the time to wait (in milliseconds) before closing the socket

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -6,7 +6,7 @@ class SMTPResponse {
 	 * @constructor
 	 * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
 	 * @param {number} timeout the time to wait (in milliseconds) before closing the socket
-	 * @param {Function} onerror the function to call on error
+	 * @param {function(Error): void} onerror the function to call on error
 	 */
 	constructor(stream, timeout, onerror) {
 		let buffer = '';
@@ -132,7 +132,7 @@ exports.SMTPResponse = SMTPResponse;
 /**
  * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
  * @param {number} timeout the time to wait (in milliseconds) before closing the socket
- * @param {Function} onerror the function to call on error
+ * @param {function(Error): void} onerror the function to call on error
  * @returns {SMTPResponse} the smtp response
  */
 exports.monitor = (stream, timeout, onerror) =>

--- a/smtp/response.js
+++ b/smtp/response.js
@@ -1,9 +1,10 @@
 const SMTPError = require('./error');
+const { TLSSocket } = require('tls');
 
 class SMTPResponse {
 	/**
 	 * @constructor
-	 * @param {Socket | TLSSocket} stream the open socket to stream a response from
+	 * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
 	 * @param {number} timeout the time to wait (in milliseconds) before closing the socket
 	 * @param {Function} onerror the function to call on error
 	 */
@@ -104,26 +105,30 @@ class SMTPResponse {
 		 */
 		this.stop = err => {
 			stream.removeAllListeners('response');
-			stream.removeListener('data', watch);
-			stream.removeListener('end', end);
-			stream.removeListener('close', close);
-			stream.removeListener('error', error);
+			if (stream instanceof TLSSocket) {
+				stream.removeListener('data', watch);
+				stream.removeListener('end', end);
+				stream.removeListener('close', close);
+				stream.removeListener('error', error);
+			}
 
 			if (err != null && typeof onerror === 'function') {
 				onerror(err);
 			}
 		};
 
-		stream.on('data', watch);
-		stream.on('end', end);
-		stream.on('close', close);
-		stream.on('error', error);
-		stream.setTimeout(timeout, timedout);
+		if (stream instanceof TLSSocket) {
+			stream.on('data', watch);
+			stream.on('end', end);
+			stream.on('close', close);
+			stream.on('error', error);
+			stream.setTimeout(timeout, timedout);
+		}
 	}
 }
 
 /**
- * @param {Socket | TLSSocket} stream the open socket to stream a response from
+ * @param {NodeJS.Socket | TLSSocket} stream the open socket to stream a response from
  * @param {number} timeout the time to wait (in milliseconds) before closing the socket
  * @param {Function} onerror the function to call on error
  * @returns {SMTPResponse} the smtp response

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -684,7 +684,7 @@ class SMTP extends EventEmitter {
 				);
 
 			/**
-			 * see: https://developers.google.com/gmail/xoauth2_protocol
+			 * @see https://developers.google.com/gmail/xoauth2_protocol
 			 * @returns {string} base64 xoauth2 auth token
 			 */
 			const encode_xoauth2 = () =>

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -10,15 +10,39 @@ const { EventEmitter } = require('events');
 const SMTPResponse = require('./response');
 const SMTPError = require('./error');
 
+/**
+ * @readonly
+ * @type {25}
+ */
 const SMTP_PORT = 25;
+
+/**
+ * @readonly
+ * @type {465}
+ */
 const SMTP_SSL_PORT = 465;
+
+/**
+ * @readonly
+ * @type {587}
+ */
 const SMTP_TLS_PORT = 587;
+
+/**
+ * @readonly
+ * @type {'\r\n'}
+ */
 const CRLF = '\r\n';
+
+/**
+ * @readonly
+ * @enum
+ */
 const AUTH_METHODS = {
-	PLAIN: 'PLAIN',
-	CRAM_MD5: 'CRAM-MD5',
-	LOGIN: 'LOGIN',
-	XOAUTH2: 'XOAUTH2',
+	PLAIN: /** @type {'PLAIN'} */ ('PLAIN'),
+	CRAM_MD5: /** @type {'CRAM-MD5'} */ ('CRAM-MD5'),
+	LOGIN: /** @type {'LOGIN'} */ ('LOGIN'),
+	XOAUTH2: /** @type {'XOAUTH2'} */ ('XOAUTH2'),
 };
 
 const TIMEOUT = 5000;

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -110,11 +110,13 @@ class SMTP extends EventEmitter {
 		super();
 
 		/**
+		 * @private
 		 * @type {number}
 		 */
 		this._state = SMTPState.NOTCONNECTED;
 
 		/**
+		 * @private
 		 * @type {boolean}
 		 */
 		this._secure = false;

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -86,7 +86,6 @@ class SMTP extends EventEmitter {
 			authentication,
 		} = Object.assign(
 			{
-				timeout: TIMEOUT,
 				domain: hostname(),
 				host: 'localhost',
 				ssl: false,

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -46,6 +46,10 @@ const AUTH_METHODS = {
 };
 
 const TIMEOUT = 5000;
+
+/**
+ * @type {0 | 1}
+ */
 let DEBUG = 0;
 
 /**
@@ -53,7 +57,7 @@ let DEBUG = 0;
  * @returns {void}
  */
 const log = (...args) => {
-	if (DEBUG) {
+	if (DEBUG === 1) {
 		args.forEach(d => console.log(d));
 	}
 };
@@ -199,7 +203,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {number} level -
+	 * @param {0 | 1} level -
 	 * @returns {void}
 	 */
 	debug(level) {

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -12,6 +12,12 @@ const SMTPError = require('./error');
 
 /**
  * @readonly
+ * @type {5000}
+ */
+const TIMEOUT = 5000;
+
+/**
+ * @readonly
  * @type {25}
  */
 const SMTP_PORT = 25;
@@ -44,8 +50,6 @@ const AUTH_METHODS = {
 	LOGIN: /** @type {'LOGIN'} */ ('LOGIN'),
 	XOAUTH2: /** @type {'XOAUTH2'} */ ('XOAUTH2'),
 };
-
-const TIMEOUT = 5000;
 
 /**
  * @type {0 | 1}

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -35,8 +35,8 @@ const log = (...args) => {
 };
 
 /**
- * @param {Function} callback the function to call
- * @param {...any} args the arguments to apply to the function
+ * @param {function(...*): void} callback the function to call
+ * @param {...*} args the arguments to apply to the function
  * @returns {void}
  */
 const caller = (callback, ...args) => {
@@ -193,7 +193,7 @@ class SMTP extends EventEmitter {
 	 * @typedef {Object} ConnectOptions
 	 * @property {boolean} [ssl]
 	 *
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {number} [port] the port to use for the connection
 	 * @param {string} [host] the hostname to use for the connection
 	 * @param {ConnectOptions} [options={}] the options
@@ -332,7 +332,7 @@ class SMTP extends EventEmitter {
 
 	/**
 	 * @param {string} cmd command to issue
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {(number[] | number)} [codes=[250]] array codes
 	 * @returns {void}
 	 */
@@ -371,7 +371,7 @@ class SMTP extends EventEmitter {
 	 * Hostname to send for self command defaults to the FQDN of the local
 	 * host.
 	 *
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} domain the domain to associate with the 'helo' request
 	 * @returns {void}
 	 */
@@ -387,7 +387,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	starttls(callback) {
@@ -445,7 +445,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} domain the domain to associate with the 'ehlo' request
 	 * @returns {void}
 	 */
@@ -476,7 +476,7 @@ class SMTP extends EventEmitter {
 
 	/**
 	 * SMTP 'help' command, returns text from the server
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} domain the domain to associate with the 'help' request
 	 * @returns {void}
 	 */
@@ -485,7 +485,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	rset(callback) {
@@ -493,7 +493,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	noop(callback) {
@@ -501,7 +501,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} from the sender
 	 * @returns {void}
 	 */
@@ -510,7 +510,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} to the receiver
 	 * @returns {void}
 	 */
@@ -519,7 +519,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	data(callback) {
@@ -527,7 +527,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	data_end(callback) {
@@ -547,7 +547,7 @@ class SMTP extends EventEmitter {
 	 * SMTP 'verify' command -- checks for address validity.
 	 *
 	 * @param {string} address the address to validate
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	verify(address, callback) {
@@ -558,7 +558,7 @@ class SMTP extends EventEmitter {
 	 * SMTP 'expn' command -- expands a mailing list.
 	 *
 	 * @param {string} address the mailing list to expand
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @returns {void}
 	 */
 	expn(address, callback) {
@@ -571,7 +571,7 @@ class SMTP extends EventEmitter {
 	 * If there has been no previous EHLO or HELO command self session, self
 	 * method tries ESMTP EHLO first.
 	 *
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} [domain] the domain to associate with the command
 	 * @returns {void}
 	 */
@@ -597,7 +597,7 @@ class SMTP extends EventEmitter {
 	 *
 	 * This method will return normally if the authentication was successful.
 	 *
-	 * @param {Function} callback function to call after response
+	 * @param {function(...*): void} callback function to call after response
 	 * @param {string} [user] the username to authenticate with
 	 * @param {string} [password] the password for the authentication
 	 * @param {{ method: string, domain: string }} [options] login options
@@ -768,7 +768,7 @@ class SMTP extends EventEmitter {
 	}
 
 	/**
-	 * @param {Function} [callback] function to call after response
+	 * @param {function(...*): void} [callback] function to call after response
 	 * @returns {void}
 	 */
 	quit(callback) {

--- a/smtp/smtp.js
+++ b/smtp/smtp.js
@@ -67,38 +67,18 @@ class SMTP extends EventEmitter {
 	 * @constructor
 	 * @param {SMTPOptions} [options] instance options
 	 */
-	constructor(options = {}) {
+	constructor({
+		timeout,
+		host,
+		user,
+		password,
+		domain,
+		port,
+		ssl,
+		tls,
+		authentication,
+	} = {}) {
 		super();
-
-		if (options.timeout == null) {
-			options.timeout = TIMEOUT;
-		}
-
-		const {
-			timeout,
-			user,
-			password,
-			domain,
-			host,
-			port,
-			ssl,
-			tls,
-			authentication,
-		} = Object.assign(
-			{
-				domain: hostname(),
-				host: 'localhost',
-				ssl: false,
-				tls: false,
-				authentication: [
-					AUTH_METHODS.CRAM_MD5,
-					AUTH_METHODS.LOGIN,
-					AUTH_METHODS.PLAIN,
-					AUTH_METHODS.XOAUTH2,
-				],
-			},
-			options
-		);
 
 		/**
 		 * @type {number}
@@ -128,32 +108,39 @@ class SMTP extends EventEmitter {
 		/**
 		 * @type {string[]}
 		 */
-		this.authentication = authentication;
+		this.authentication = Array.isArray(authentication)
+			? authentication
+			: [
+					AUTH_METHODS.CRAM_MD5,
+					AUTH_METHODS.LOGIN,
+					AUTH_METHODS.PLAIN,
+					AUTH_METHODS.XOAUTH2,
+			  ];
 
 		/**
-		 * @type {number}[] }
+		 * @type {number} }
 		 */
-		this.timeout = timeout;
+		this.timeout = typeof timeout === 'number' ? timeout : TIMEOUT;
 
 		/**
 		 * @type {string} }
 		 */
-		this.domain = domain;
+		this.domain = typeof domain === 'string' ? domain : hostname();
 
 		/**
 		 * @type {string} }
 		 */
-		this.host = host;
+		this.host = typeof host === 'string' ? host : 'localhost';
 
 		/**
 		 * @type {boolean}
 		 */
-		this.ssl = ssl;
+		this.ssl = typeof ssl === 'boolean' ? ssl : false;
 
 		/**
 		 * @type {boolean}
 		 */
-		this.tls = tls;
+		this.tls = typeof tls === 'boolean' ? tls : false;
 
 		/**
 		 * @type {number}
@@ -166,8 +153,8 @@ class SMTP extends EventEmitter {
 		this.loggedin = user && password ? false : true;
 
 		// keep these strings hidden when quicky debugging/logging
-		this.user = /** @returns {string} */ () => options.user;
-		this.password = /** @returns {string} */ () => options.password;
+		this.user = /** @returns {string} */ () => user;
+		this.password = /** @returns {string} */ () => password;
 	}
 
 	/**

--- a/test/server.js
+++ b/test/server.js
@@ -29,19 +29,29 @@ describe('Connect to wrong email server', function() {
 
 	it('should have a default timeout', function(done) {
 		const connectionOptions = {
-			user: "username",
-			password: "password",
-			host: "127.0.0.1",
+			user: 'username',
+			password: 'password',
+			host: '127.0.0.1',
 			port: 1234,
 		};
 
-		assert.strictEqual(email.server.connect(connectionOptions).smtp.timeout, email.SMTP.DEFAULT_TIMEOUT);
+		const email = require(emailModulePath);
+		assert.strictEqual(
+			email.server.connect(connectionOptions).smtp.timeout,
+			email.SMTP.DEFAULT_TIMEOUT
+		);
 
 		connectionOptions.timeout = null;
-		assert.strictEqual(email.server.connect(connectionOptions).smtp.timeout, email.SMTP.DEFAULT_TIMEOUT);
+		assert.strictEqual(
+			email.server.connect(connectionOptions).smtp.timeout,
+			email.SMTP.DEFAULT_TIMEOUT
+		);
 
 		connectionOptions.timeout = undefined;
-		assert.strictEqual(email.server.connect(connectionOptions).smtp.timeout, email.SMTP.DEFAULT_TIMEOUT);
+		assert.strictEqual(
+			email.server.connect(connectionOptions).smtp.timeout,
+			email.SMTP.DEFAULT_TIMEOUT
+		);
 
 		done();
 	});

--- a/test/server.js
+++ b/test/server.js
@@ -3,18 +3,16 @@ const assert = require('assert');
 
 describe('Connect to wrong email server', function() {
 	const emailModulePath = require.resolve(path.join(__dirname, '..', 'email'));
-	let email;
 
 	beforeEach(function() {
 		if (require.cache[emailModulePath]) {
 			delete require.cache[emailModulePath];
 		}
-		email = require('../email');
 	});
 
 	it('Should not call callback multiple times with wrong server configuration', function(done) {
 		this.timeout(5000);
-		const server = email.server.connect({ host: 'bar.baz' });
+		const server = require(emailModulePath).server.connect({ host: 'bar.baz' });
 		server.send(
 			{
 				from: 'foo@bar.baz',

--- a/test/server.js
+++ b/test/server.js
@@ -1,18 +1,23 @@
-const path = require('path');
 const assert = require('assert');
 
 describe('Connect to wrong email server', function() {
-	const emailModulePath = require.resolve(path.join(__dirname, '..', 'email'));
+	const emailModulePath = require.resolve('../email.js');
+
+	/**
+	 * @type {typeof import('../email.js')}
+	 */
+	let email = null;
 
 	beforeEach(function() {
 		if (require.cache[emailModulePath]) {
 			delete require.cache[emailModulePath];
 		}
+		email = require(emailModulePath);
 	});
 
 	it('Should not call callback multiple times with wrong server configuration', function(done) {
 		this.timeout(5000);
-		const server = require(emailModulePath).server.connect({ host: 'bar.baz' });
+		const server = email.server.connect({ host: 'bar.baz' });
 		server.send(
 			{
 				from: 'foo@bar.baz',

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,10 +971,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-starttls@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/starttls/-/starttls-1.0.1.tgz#e6081c25de6b178f5a75f8f271c1487449183b42"
-
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"


### PR DESCRIPTION
since you had mentioned adding types to the project, i thought i'd start with a baseline effort of adding jsdoc types where i could. flow can't use them, but [typescript can](https://github.com/Microsoft/TypeScript/wiki/JSDoc-support-in-JavaScript), and vscode can take advantage of that using its `javascript.implicitProjectConfig.checkJs` setting. 

this does have the consequence of tying some types to typescript definitions; this can be addressed if it's a problem:
- NodeJS.ErrnoException [1](https://github.com/eleith/emailjs/pull/224/files#diff-892b5b114263762324908b974ad6b2bdR387)
- NodeJS.ReadWriteStream [1](https://github.com/eleith/emailjs/pull/224/files#diff-892b5b114263762324908b974ad6b2bdR237)
- NodeJS.Timer [1](https://github.com/eleith/emailjs/pull/224/commits/96e323c0947127eaa50ca0e6ea3e1280d7d49168#diff-058786dd50ece0290fde266dfcd6fbfaR42)

i tried to type it against the code as best as i could; some places (like the `smtp` param in `error`) i had no idea to type, so i defaulted to `*`. i'm 95% confident in the accuracy of what i did type.

a lot of the jsdoc descriptions are placeholders/junk thrown in to satisfy eslint's `valid-jsdoc` rule. i figured if it was important it could be addressed later; this took me a little while to pull together so i was eager to get code out the door :) 

the types did point out some incorrect code; those discrepancies have been addressed. in a couple cases i asserted errors away ([1](https://github.com/eleith/emailjs/pull/224/files#diff-058786dd50ece0290fde266dfcd6fbfaR148), [2](https://github.com/eleith/emailjs/pull/224/files#diff-058786dd50ece0290fde266dfcd6fbfaL158) for example) where a refactor might be more appropriate.

as to dropping `starttls` - while i was adding the types i noticed it's technically not callable, as any version of node that can run the code would have access to the `TLSSocket` api. it seemed pretty cut-and-dried to me, though if i'm missing something here i'll gladly revert.

similarly, some checks against node apis that are guaranteed to exist/not exist were removed as well.

tests continue to pass :)