### PR TITLE
smtp: fix regression in address type validation

### DIFF
--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -92,31 +92,32 @@ export class SMTPClient {
 			callback: callback.bind(this),
 		} as MessageStack;
 
-		if (typeof message.header.to === 'string') {
-			stack.to = addressparser(message.header.to);
+		const {
+			header: { to, cc, bcc, 'return-path': returnPath },
+		} = message;
+
+		if ((typeof to === 'string' || Array.isArray(to)) && to.length > 0) {
+			stack.to = addressparser(to);
 		}
 
-		if (typeof message.header.cc === 'string') {
+		if ((typeof cc === 'string' || Array.isArray(cc)) && cc.length > 0) {
 			stack.to = stack.to.concat(
-				addressparser(message.header.cc).filter(
+				addressparser(cc).filter(
 					(x) => stack.to.some((y) => y.address === x.address) === false
 				)
 			);
 		}
 
-		if (typeof message.header.bcc === 'string') {
+		if ((typeof bcc === 'string' || Array.isArray(bcc)) && bcc.length > 0) {
 			stack.to = stack.to.concat(
-				addressparser(message.header.bcc).filter(
+				addressparser(bcc).filter(
 					(x) => stack.to.some((y) => y.address === x.address) === false
 				)
 			);
 		}
 
-		if (
-			typeof message.header['return-path'] === 'string' &&
-			message.header['return-path'].length > 0
-		) {
-			const parsedReturnPath = addressparser(message.header['return-path']);
+		if (typeof returnPath === 'string' && returnPath.length > 0) {
+			const parsedReturnPath = addressparser(returnPath);
 			if (parsedReturnPath.length > 0) {
 				const [{ address: returnPathAddress }] = parsedReturnPath;
 				stack.returnPath = returnPathAddress;

--- a/smtp/message.ts
+++ b/smtp/message.ts
@@ -57,15 +57,21 @@ export interface MessageAttachment {
 }
 
 export interface MessageHeaders {
-	[index: string]: string | null | MessageAttachment | MessageAttachment[];
+	[index: string]:
+		| boolean
+		| string
+		| string[]
+		| null
+		| MessageAttachment
+		| MessageAttachment[];
 	'content-type': string;
 	'message-id': string;
 	'return-path': string | null;
 	date: string;
-	from: string;
-	to: string;
-	cc: string;
-	bcc: string;
+	from: string | string[];
+	to: string | string[];
+	cc: string | string[];
+	bcc: string | string[];
 	subject: string;
 	text: string | null;
 	attachment: MessageAttachment | MessageAttachment[];
@@ -85,7 +91,7 @@ function generate_boundary() {
 	return text;
 }
 
-function convertPersonToAddress(person: string) {
+function convertPersonToAddress(person: string | string[]) {
 	return addressparser(person)
 		.map(({ name, address }) => {
 			return name
@@ -147,7 +153,7 @@ export class Message {
 				this.header.subject = mimeWordEncode(headers.subject);
 			} else if (/^(cc|bcc|to|from)/i.test(header)) {
 				this.header[header.toLowerCase()] = convertPersonToAddress(
-					headers[header] as string
+					headers[header] as string | string[]
 				);
 			} else {
 				// allow any headers the user wants to set??
@@ -185,12 +191,18 @@ export class Message {
 	 * @returns {void}
 	 */
 	public valid(callback: (isValid: boolean, invalidReason?: string) => void) {
-		if (typeof this.header.from !== 'string') {
+		if (
+			typeof this.header.from !== 'string' &&
+			Array.isArray(this.header.from) === false
+		) {
 			callback(false, 'Message must have a `from` header');
 		} else if (
 			typeof this.header.to !== 'string' &&
+			Array.isArray(this.header.to) === false &&
 			typeof this.header.cc !== 'string' &&
-			typeof this.header.bcc !== 'string'
+			Array.isArray(this.header.cc) === false &&
+			typeof this.header.bcc !== 'string' &&
+			Array.isArray(this.header.bcc) === false
 		) {
 			callback(
 				false,

--- a/smtp/typings.d.ts
+++ b/smtp/typings.d.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-var */
 declare module 'addressparser' {
-	var addressparser: (address?: string) => { name: string; address: string }[];
+	var addressparser: (
+		address?: string | string[]
+	) => { name: string; address: string }[];
 	export = addressparser;
 }
 

--- a/test/client.ts
+++ b/test/client.ts
@@ -85,9 +85,47 @@ test('client deduplicates recipients', (t) => {
 		cc: 'gannon@gmail.com',
 		bcc: 'gannon@gmail.com',
 	};
-	const stack = new SMTPClient({}).createMessageStack(new Message(msg));
+	const stack = client.createMessageStack(new Message(msg));
 	t.true(stack.to.length === 1);
 	t.is(stack.to[0].address, 'gannon@gmail.com');
+});
+
+test.cb('client accepts array recipients', (t) => {
+	const msg = new Message({
+		from: 'zelda@gmail.com',
+		to: ['gannon1@gmail.com'],
+		cc: ['gannon2@gmail.com'],
+		bcc: ['gannon3@gmail.com'],
+	});
+
+	msg.header.to = [msg.header.to as string];
+	msg.header.cc = [msg.header.cc as string];
+	msg.header.bcc = [msg.header.bcc as string];
+
+	msg.valid((isValid) => {
+		t.true(isValid);
+		const stack = client.createMessageStack(msg);
+		t.is(stack.to.length, 3);
+		t.deepEqual(
+			stack.to.map((x) => x.address),
+			['gannon1@gmail.com', 'gannon2@gmail.com', 'gannon3@gmail.com']
+		);
+		t.end();
+	});
+});
+
+test.cb('client accepts array sender', (t) => {
+	const msg = new Message({
+		from: ['zelda@gmail.com'],
+		to: ['gannon1@gmail.com'],
+	});
+
+	msg.header.from = [msg.header.from as string];
+
+	msg.valid((isValid) => {
+		t.true(isValid);
+		t.end();
+	});
 });
 
 test.cb('client rejects message without `from` header', (t) => {

--- a/test/message.ts
+++ b/test/message.ts
@@ -465,24 +465,95 @@ test.cb('message validation fails without `to`, `cc`, or `bcc` header', (t) => {
 	});
 });
 
-test.cb('message validation succeeds with only `cc` recipient header', (t) => {
-	const msg = new Message({
-		from: 'piglet@gmail.com',
-		cc: 'pooh@gmail.com',
-	});
-	msg.valid((isValid) => {
-		t.true(isValid);
-		t.end();
-	});
-});
+test.cb(
+	'message validation succeeds with only `to` recipient header (string)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			to: 'pooh@gmail.com',
+		});
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);
 
-test.cb('message validation succeeds with only `bcc` recipient header', (t) => {
-	const msg = new Message({
-		from: 'piglet@gmail.com',
-		bcc: 'pooh@gmail.com',
-	});
-	msg.valid((isValid) => {
-		t.true(isValid);
-		t.end();
-	});
-});
+test.cb(
+	'message validation succeeds with only `to` recipient header (array)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			to: ['pooh@gmail.com'],
+		});
+		msg.header.to = [msg.header.to as string];
+		msg.header.cc = [];
+		msg.header.bcc = [];
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);
+
+test.cb(
+	'message validation succeeds with only `cc` recipient header (string)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			cc: 'pooh@gmail.com',
+		});
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);
+
+test.cb(
+	'message validation succeeds with only `cc` recipient header (array)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			cc: ['pooh@gmail.com'],
+		});
+		msg.header.to = [];
+		msg.header.cc = [msg.header.cc as string];
+		msg.header.bcc = [];
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);
+
+test.cb(
+	'message validation succeeds with only `bcc` recipient header (string)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			bcc: 'pooh@gmail.com',
+		});
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);
+
+test.cb(
+	'message validation succeeds with only `bcc` recipient header (array)',
+	(t) => {
+		const msg = new Message({
+			from: 'piglet@gmail.com',
+			bcc: ['pooh@gmail.com'],
+		});
+		msg.header.to = [];
+		msg.header.cc = [];
+		msg.header.bcc = [msg.header.bcc as string];
+		msg.valid((isValid) => {
+			t.true(isValid);
+			t.end();
+		});
+	}
+);


### PR DESCRIPTION
in my zeal, i changed truthy checks that allowed arrays for recipients to hard type checks. this PR adds array checks to validation, as well as tests to prevent future regressions.