### PR TITLE
avoid typescript error

### DIFF
--- a/smtp/mime.ts
+++ b/smtp/mime.ts
@@ -80,7 +80,7 @@ function encodeBase64(data: Uint8Array) {
 function splitMimeEncodedString(str: string, maxlen = 12) {
 	const minWordLength = 12; // require at least 12 symbols to fit possible 4 octet UTF-8 sequences
 	const maxWordLength = Math.max(maxlen, minWordLength);
-	const lines = [] as string[];
+	const lines: string[] = [];
 
 	while (str.length) {
 		let curLine = str.substr(0, maxWordLength);
@@ -189,7 +189,7 @@ export function mimeWordEncode(
 	mimeWordEncoding: 'Q' | 'B' = 'Q',
 	encoding = 'utf-8'
 ) {
-	let parts = [] as string[];
+	let parts: string[] = [];
 	const decoder = new TextDecoder(encoding);
 	const str = typeof data === 'string' ? data : decoder.decode(data);
 

--- a/smtp/mime.ts
+++ b/smtp/mime.ts
@@ -80,7 +80,7 @@ function encodeBase64(data: Uint8Array) {
 function splitMimeEncodedString(str: string, maxlen = 12) {
 	const minWordLength = 12; // require at least 12 symbols to fit possible 4 octet UTF-8 sequences
 	const maxWordLength = Math.max(maxlen, minWordLength);
-	const lines = [];
+	const lines = [] as string[];
 
 	while (str.length) {
 		let curLine = str.substr(0, maxWordLength);

--- a/smtp/mime.ts
+++ b/smtp/mime.ts
@@ -189,7 +189,7 @@ export function mimeWordEncode(
 	mimeWordEncoding: 'Q' | 'B' = 'Q',
 	encoding = 'utf-8'
 ) {
-	let parts = [];
+	let parts = [] as string[];
 	const decoder = new TextDecoder(encoding);
 	const str = typeof data === 'string' ? data : decoder.decode(data);
 


### PR DESCRIPTION
keeps the following errors from happening when compiling (with `strict: true` in tsconfig.json):
```
node_modules/emailjs/smtp/mime.ts:109:15 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.

109             lines.push(curLine);
                           ~~~~~~~

node_modules/emailjs/smtp/mime.ts:206:3 - error TS2322: Type 'string[]' is not assignable to type 'never[]'.
  Type 'string' is not assignable to type 'never'.

206     parts =
        ~~~~~

node_modules/emailjs/smtp/mime.ts:220:16 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.

                                   ~~~~~~~~~~~~~~~~~~~~~~~

node_modules/emailjs/smtp/mime.ts:227:34 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.

227     str.substring(j) && parts.push(str.substring(j));
                                       ~~~~~~~~~~~~~~~~

node_modules/emailjs/smtp/mime.ts:228:3 - error TS2322: Type 'string[]' is not assignable to type 'never[]'.
  Type 'string' is not assignable to type 'never'.

228     parts = parts.map((x) => encoder.encode(x)).map((x) => encodeBase64(x));
        ~~~~~
```