### PR TITLE
test: enable concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"build": "rollup -c rollup.config.ts",
 		"lint": "eslint *.ts \"+(smtp|test)/*.ts\"",
 		"tsc": "tsc",
-		"test": "ava --serial",
+		"test": "ava",
 		"test-cjs": "npm run build && npm run test -- --node-arguments='--title=cjs'"
 	},
 	"license": "MIT"

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -32,7 +32,7 @@ function onAuth(
 	}
 }
 
-let port = 1000;
+let port = 5000;
 function send(
 	t: CbExecutionContext,
 	{

--- a/test/client.ts
+++ b/test/client.ts
@@ -8,45 +8,51 @@ import { DEFAULT_TIMEOUT, SMTPClient, Message } from '../email';
 
 type UnPromisify<T> = T extends Promise<infer U> ? U : T;
 
-let port = 3000;
+const port = 3000;
 let greylistPort = 4000;
+
+const client = new SMTPClient({
+	port,
+	user: 'pooh',
+	password: 'honey',
+	ssl: true,
+});
+const server = new SMTPServer({
+	secure: true,
+	onAuth(auth, _session, callback) {
+		if (auth.username === 'pooh' && auth.password === 'honey') {
+			callback(null, { user: 'pooh' });
+		} else {
+			return callback(new Error('invalid user / pass'));
+		}
+	},
+});
+
+test.before.cb((t) => {
+	server.listen(port, () => t.end());
+});
+
+const { onData } = server;
+test.afterEach(async () => {
+	server.onData = onData;
+});
 
 function send(
 	t: CbExecutionContext,
 	message: Message,
 	verify: (mail: UnPromisify<ReturnType<typeof simpleParser>>) => void
 ) {
-	const server = new SMTPServer({
-		secure: true,
-		onAuth(auth, _session, callback) {
-			if (auth.username === 'pooh' && auth.password === 'honey') {
-				callback(null, { user: 'pooh' });
-			} else {
-				return callback(new Error('invalid user / pass'));
-			}
-		},
-		async onData(stream, _session, callback: () => void) {
-			const mail = await simpleParser(stream, {
-				skipHtmlToText: true,
-				skipTextToHtml: true,
-				skipImageLinks: true,
-			} as Record<string, unknown>);
-			verify(mail);
-			callback();
-		},
-	});
-
-	const p = port++;
-	server.listen(p, () => {
-		new SMTPClient({
-			port: p,
-			user: 'pooh',
-			password: 'honey',
-			ssl: true,
-		}).send(message, (err) => {
-			server.close();
-			t.end(err);
-		});
+	server.onData = async (stream, _session, callback: () => void) => {
+		const mail = await simpleParser(stream, {
+			skipHtmlToText: true,
+			skipTextToHtml: true,
+			skipImageLinks: true,
+		} as Record<string, unknown>);
+		verify(mail);
+		callback();
+	};
+	client.send(message, (err) => {
+		t.end(err);
 	});
 }
 

--- a/test/date.ts
+++ b/test/date.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-
 import { getRFC2822Date, getRFC2822DateUTC } from '../email';
 
 const toD_utc = (dt: number) => getRFC2822DateUTC(new Date(dt));

--- a/test/message.ts
+++ b/test/message.ts
@@ -9,7 +9,7 @@ import { SMTPClient, Message, MessageAttachment } from '../email';
 
 type UnPromisify<T> = T extends Promise<infer U> ? U : T;
 
-let port = 4000;
+let port = 5000;
 
 function send(
 	t: CbExecutionContext,
@@ -25,13 +25,14 @@ function send(
 				return callback(new Error('invalid user / pass'));
 			}
 		},
-		onData(stream, _session, callback: () => void) {
-			simpleParser(stream, {
+		async onData(stream, _session, callback: () => void) {
+			const mail = await simpleParser(stream, {
 				skipHtmlToText: true,
 				skipTextToHtml: true,
 				skipImageLinks: true,
-			} as Record<string, unknown>).then(verify);
-			stream.on('end', callback);
+			} as Record<string, unknown>);
+			verify(mail);
+			callback();
 		},
 	});
 	const p = port++;

--- a/test/message.ts
+++ b/test/message.ts
@@ -28,14 +28,7 @@ const server = new SMTPServer({
 	},
 });
 
-test.before.cb((t) => {
-	server.listen(port, () => t.end());
-});
-
 const { onData } = server;
-test.afterEach(async () => {
-	server.onData = onData;
-});
 
 function send(
 	t: CbExecutionContext,
@@ -55,6 +48,14 @@ function send(
 		t.end(err);
 	});
 }
+
+test.before(async (t) => {
+	server.listen(port, t.pass);
+});
+
+test.afterEach(async () => {
+	server.onData = onData;
+});
 
 test.cb('simple text message', (t) => {
 	const msg = {

--- a/test/mime.ts
+++ b/test/mime.ts
@@ -2,23 +2,23 @@
 import test from 'ava';
 import { mimeEncode, mimeWordEncode } from '../email';
 
-test('mimeEncode should encode UTF-8', (t) => {
+test('mimeEncode should encode UTF-8', async (t) => {
 	t.is(mimeEncode('tere ÕÄÖÕ'), 'tere =C3=95=C3=84=C3=96=C3=95');
 });
 
-test('mimeEncode should encode trailing whitespace', (t) => {
+test('mimeEncode should encode trailing whitespace', async (t) => {
 	t.is(mimeEncode('tere  '), 'tere =20');
 });
 
-test('mimeEncode should encode non UTF-8', (t) => {
+test('mimeEncode should encode non UTF-8', async (t) => {
 	t.is(mimeEncode(new Uint8Array([0xbd, 0xc5]), 'utf-16be'), '=EB=B7=85');
 });
 
-test('mimeWordEncode should encode', (t) => {
+test('mimeWordEncode should encode', async (t) => {
 	t.is('=?UTF-8?Q?See_on_=C3=B5hin_test?=', mimeWordEncode('See on õhin test'));
 });
 
-test('mimeWordEncode should QP-encode mime word', (t) => {
+test('mimeWordEncode should QP-encode mime word', async (t) => {
 	t.is(
 		'=?UTF-8?Q?=E4=AB=B5=E6=9D=A5=E2=B5=B6=E6=87=9E?=',
 		mimeWordEncode(
@@ -29,14 +29,14 @@ test('mimeWordEncode should QP-encode mime word', (t) => {
 	);
 });
 
-test('mimeWordEncode should Base64-encode mime word', (t) => {
+test('mimeWordEncode should Base64-encode mime word', async (t) => {
 	t.is(
 		mimeWordEncode('Привет и до свидания', 'B'),
 		'=?UTF-8?B?0J/RgNC40LLQtdGCINC4INC00L4g0YHQstC40LTQsNC90LjRjw==?='
 	);
 });
 
-test('mimeWordEncode should Base64-encode a long mime word', (t) => {
+test('mimeWordEncode should Base64-encode a long mime word', async (t) => {
 	const payload =
 		'üöß‹€Привет и до свиданияПривет и до свиданияПривет и до свиданияПривет и до свиданияПривет и до свиданияПривет и до свиданияПривет и до свиданияПривет и до свидания';
 	const expected =


### PR DESCRIPTION
refactoring the test suite to get rid of the `--serial` flag

normally i would just push to master for things like this, but i wanted to run it through PR since it changes test behavior in a large manner by moving from a "re-use server/client" model to a "create new server/client pair per test" model. ideally i would have both concurrency & re-use — since imo that would provide more confidence in the internals — but merely enabling concurrency cuts test times by ~2/3rds so i figure it might be ok to restore re-use in a future changeset.