### PR TITLE
smtp/client: support async/await workflows

### DIFF
--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -63,6 +63,9 @@ export class SMTPClient {
 				}
 				this.queue.push(stack);
 				this._poll();
+				if (this.queue.every((x) => x !== stack)) {
+					callback(null, message);
+				}
 			} else {
 				callback(new Error(why), msg);
 			}

--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -74,6 +74,23 @@ export class SMTPClient {
 
 	/**
 	 * @public
+	 * @param {Message} msg the message to send
+	 * @returns {Promise<Message>} a promise that resolves to the fully processed message
+	 */
+	public sendAsync(msg: Message) {
+		return new Promise<Message>((resolve, reject) => {
+			this.send(msg, (err, msg) => {
+				if (err != null) {
+					reject(err);
+				} else {
+					resolve(msg);
+				}
+			});
+		});
+	}
+
+	/**
+	 * @public
 	 * @description Converts a message to the raw object used by the internal stack.
 	 * @param {Message} message message to convert
 	 * @param {function(err: Error, msg: Message): void} callback errback

--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -63,9 +63,6 @@ export class SMTPClient {
 				}
 				this.queue.push(stack);
 				this._poll();
-				if (this.queue.every((x) => x !== stack)) {
-					callback(null, message);
-				}
 			} else {
 				callback(new Error(why), msg);
 			}

--- a/smtp/connection.ts
+++ b/smtp/connection.ts
@@ -120,10 +120,7 @@ export class SMTPConnection extends EventEmitter {
 	protected tls: boolean | SMTPSocketOptions = false;
 	protected port: number;
 
-	private greylistResponseTracker = new WeakMap<
-		(...rest: any[]) => void,
-		boolean
-	>();
+	private greylistResponseTracker = new WeakSet<(...rest: any[]) => void>();
 
 	/**
 	 * SMTP class written using python's (2.7) smtplib.py as a base.
@@ -411,9 +408,9 @@ export class SMTPConnection extends EventEmitter {
 				} else if (
 					(code === 450 || code === 451) &&
 					msg.message.toLowerCase().includes('greylist') &&
-					this.greylistResponseTracker.get(response) === false
+					this.greylistResponseTracker.has(response) === false
 				) {
-					this.greylistResponseTracker.set(response, true);
+					this.greylistResponseTracker.add(response);
 					setTimeout(() => {
 						this.send(cmd + CRLF, response);
 					}, GREYLIST_DELAY);
@@ -435,7 +432,7 @@ export class SMTPConnection extends EventEmitter {
 			}
 		};
 
-		this.greylistResponseTracker.set(response, false);
+		this.greylistResponseTracker.delete(response);
 		this.send(cmd + CRLF, response);
 	}
 

--- a/smtp/date.ts
+++ b/smtp/date.ts
@@ -33,3 +33,18 @@ export function getRFC2822DateUTC(date = new Date()) {
 	dates.push('+0000');
 	return dates.join(' ');
 }
+
+/**
+ * RFC 2822 regex
+ * @see https://tools.ietf.org/html/rfc2822#section-3.3
+ * @see https://github.com/moment/moment/blob/a831fc7e2694281ce31e4f090bbcf90a690f0277/src/lib/create/from-string.js#L101
+ */
+const rfc2822re = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|([+-]\d{4}))$/.compile();
+
+/**
+ * @param {string} [date] a string to check for conformance to the [rfc2822](https://tools.ietf.org/html/rfc2822#section-3.3) standard
+ * @returns {boolean} the result of the conformance check
+ */
+export function isRFC2822Date(date: string) {
+	return rfc2822re.test(date);
+}

--- a/test/client.ts
+++ b/test/client.ts
@@ -373,3 +373,51 @@ test('client send can have result awaited when promisified', async (t) => {
 		t.fail(err);
 	}
 });
+
+test('client sendAsync can have result awaited', async (t) => {
+	const msg = {
+		subject: 'this is a test TEXT message from emailjs',
+		from: 'piglet@gmail.com',
+		bcc: 'pooh@gmail.com',
+		text: "It is hard to be brave when you're only a Very Small Animal.",
+	};
+
+	try {
+		const message = await client.sendAsync(new Message(msg));
+		t.true(message instanceof Message);
+		t.like(message, {
+			alternative: null,
+			content: 'text/plain; charset=utf-8',
+			text: "It is hard to be brave when you're only a Very Small Animal.",
+			header: {
+				bcc: 'pooh@gmail.com',
+				from: 'piglet@gmail.com',
+				subject: '=?UTF-8?Q?this_is_a_test_TEXT_message_from_emailjs?=',
+			},
+		});
+		t.deepEqual(message.attachments, []);
+		t.true(isRFC2822Date(message.header.date as string));
+		t.regex(message.header['message-id'] as string, /^<.*[@]{1}.*>$/);
+	} catch (err) {
+		t.fail(err);
+	}
+});
+
+test('client sendAsync can have error caught when awaited', async (t) => {
+	const msg = {
+		subject: 'this is a test TEXT message from emailjs',
+		from: 'piglet@gmail.com',
+		bcc: 'pooh@gmail.com',
+		text: "It is hard to be brave when you're only a Very Small Animal.",
+	};
+
+	try {
+		const invalidClient = new SMTPClient({ host: 'bar.baz' });
+		const message = await invalidClient.sendAsync(new Message(msg));
+		t.true(message instanceof Message);
+		t.fail();
+	} catch (err) {
+		t.true(err instanceof Error);
+		t.pass();
+	}
+});

--- a/test/date.ts
+++ b/test/date.ts
@@ -1,18 +1,15 @@
 import test from 'ava';
-import { getRFC2822Date, getRFC2822DateUTC } from '../email';
+import { getRFC2822Date, getRFC2822DateUTC, isRFC2822Date } from '../email';
 
 const toD_utc = (dt: number) => getRFC2822DateUTC(new Date(dt));
 const toD = (dt: number, utc = false) => getRFC2822Date(new Date(dt), utc);
 
 test('rfc2822 non-UTC', async (t) => {
-	// RFC 2822 regex: For details see https://tools.ietf.org/html/rfc2822#section-3.3
-	// thanks to moment.js for the listing: https://github.com/moment/moment/blob/a831fc7e2694281ce31e4f090bbcf90a690f0277/src/lib/create/from-string.js#L101
-	const rfc2822re = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|([+-]\d{4}))$/;
-	t.regex(toD(0), rfc2822re);
-	t.regex(toD(329629726785), rfc2822re);
-	t.regex(toD(729629726785), rfc2822re);
-	t.regex(toD(1129629726785), rfc2822re);
-	t.regex(toD(1529629726785), rfc2822re);
+	t.true(isRFC2822Date(toD(0)));
+	t.true(isRFC2822Date(toD(329629726785)));
+	t.true(isRFC2822Date(toD(729629726785)));
+	t.true(isRFC2822Date(toD(1129629726785)));
+	t.true(isRFC2822Date(toD(1529629726785)));
 });
 
 test('rfc2822 UTC', async (t) => {


### PR DESCRIPTION
- adds test for `const message = await util.promisify(client.send.bind(client))(new Message(msg))`
- adds `Client#sendAsync` api 
    - combines `Client#send` with a simple promise wrapper
- adds `isRFC2822Date` api to the date module
    - partially verifies awaited output of `Client#sendAsync` and promisified `Client#send`
- fixes an issue with one of the tests
- alters greylist response tracker to use `WeakSet` instead of `WeakMap`

resolves #267 

assuming this gets merged, i'll prepare a PR for a `semver-minor` release