### PR TITLE
support `tsc --noPropertyAccessFromIndexSignature`

### DIFF
--- a/smtp/connection.ts
+++ b/smtp/connection.ts
@@ -762,8 +762,8 @@ export class SMTPConnection extends EventEmitter {
 				const preferred = this.authentication;
 				let auth = '';
 
-				if (typeof this.features?.auth === 'string') {
-					auth = this.features.auth;
+				if (typeof this.features?.['auth'] === 'string') {
+					auth = this.features['auth'];
 				}
 
 				for (let i = 0; i < preferred.length; i++) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"extends": "@ledge/configs/tsconfig.json",
+	"compilerOptions": {
+		"noPropertyAccessFromIndexSignature": true
+	},
 	"include": [
 		"*.ts",
 		"smtp/**/*.ts",


### PR DESCRIPTION
this fails in tsc's libcheck when noPropertyAccessFromIndexSignature is enabled