### PR TITLE
Change fs import to drop need for esModuleInterop

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ send emails, html and attachments (files, streams and strings) from node.js to a
 
 - auth access to an SMTP Server
 - if your service (ex: gmail) uses two-step authentication, use an application specific password
-- if using TypeScript, enable [`esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) or [`allowSyntheticDefaultImports`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#support-for-default-import-interop-with-systemjs)
 
 ## EXAMPLE USAGE - text only emails
 

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,4 @@
-import module from 'module';
+import { builtinModules } from 'module';
 import typescript from '@rollup/plugin-typescript';
 
 export default {
@@ -7,7 +7,7 @@ export default {
 		{
 			file: 'rollup/email.cjs',
 			format: 'cjs',
-			interop: 'default',
+			interop: false,
 			sourcemap: true,
 		},
 		{
@@ -16,7 +16,7 @@ export default {
 			sourcemap: true,
 		},
 	],
-	external: module.builtinModules,
+	external: builtinModules,
 	plugins: [
 		typescript({ removeComments: false, include: ['email.ts', 'smtp/**/*'] }),
 	],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@ledge/configs/tsconfig.json",
 	"compilerOptions": {
+		"esModuleInterop": false,
 		"noPropertyAccessFromIndexSignature": true
 	},
 	"include": [


### PR DESCRIPTION
It is only this one import that required esModuleInterop. This one change would allow everyone downstream to not require it.