### PR TITLE
message: add `checkValidity` method & deprecate `valid`

### DIFF
--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -55,18 +55,18 @@ export class SMTPClient {
 			return;
 		}
 
-		message.valid((valid, why) => {
-			if (valid) {
-				const stack = this.createMessageStack(message, callback);
-				if (stack.to.length === 0) {
-					return callback(new Error('No recipients found in message'), msg);
-				}
-				this.queue.push(stack);
-				this._poll();
-			} else {
-				callback(new Error(why), msg);
+		const { isValid, validationError } = message.checkValidity();
+
+		if (isValid) {
+			const stack = this.createMessageStack(message, callback);
+			if (stack.to.length === 0) {
+				return callback(new Error('No recipients found in message'), msg);
 			}
-		});
+			this.queue.push(stack);
+			this._poll();
+		} else {
+			callback(new Error(validationError), msg);
+		}
 	}
 
 	/**

--- a/test/client.ts
+++ b/test/client.ts
@@ -140,7 +140,7 @@ test('client accepts array recipients', async (t) => {
 	msg.header.cc = [msg.header.cc as string];
 	msg.header.bcc = [msg.header.bcc as string];
 
-	const isValid = await new Promise((r) => msg.valid(r));
+	const { isValid } = msg.checkValidity();
 	const stack = client.createMessageStack(msg);
 
 	t.true(isValid);
@@ -158,7 +158,7 @@ test('client accepts array sender', async (t) => {
 	});
 	msg.header.from = [msg.header.from as string];
 
-	const isValid = await new Promise((r) => msg.valid(r));
+	const { isValid } = msg.checkValidity();
 	t.true(isValid);
 });
 

--- a/test/message.ts
+++ b/test/message.ts
@@ -63,31 +63,6 @@ function send(headers: Partial<MessageHeaders>) {
 	});
 }
 
-function validate(headers: Partial<MessageHeaders>) {
-	const { to, cc, bcc } = headers;
-	const msg = new Message(headers);
-
-	if (Array.isArray(to)) {
-		msg.header.to = to;
-	}
-	if (Array.isArray(cc)) {
-		msg.header.to = to;
-	}
-	if (Array.isArray(bcc)) {
-		msg.header.to = to;
-	}
-
-	return new Promise((resolve, reject) => {
-		msg.valid((isValid, reason) => {
-			if (isValid) {
-				resolve(isValid);
-			} else {
-				reject(new Error(reason));
-			}
-		});
-	});
-}
-
 test.before(async (t) => {
 	server.listen(port, t.pass);
 });
@@ -401,69 +376,80 @@ test('streams message', async (t) => {
 });
 
 test('message validation fails without `from` header', async (t) => {
-	const { message: error } = await t.throwsAsync(validate({}));
-	t.is(error, 'Message must have a `from` header');
+	const msg = new Message({});
+	const { isValid, validationError } = msg.checkValidity();
+	t.false(isValid);
+	t.is(validationError, 'Message must have a `from` header');
 });
 
 test('message validation fails without `to`, `cc`, or `bcc` header', async (t) => {
-	const { message: error } = await t.throwsAsync(
-		validate({
-			from: 'piglet@gmail.com',
-		})
+	const { isValid, validationError } = new Message({
+		from: 'piglet@gmail.com',
+	}).checkValidity();
+
+	t.false(isValid);
+	t.is(
+		validationError,
+		'Message must have at least one `to`, `cc`, or `bcc` header'
 	);
-	t.is(error, 'Message must have at least one `to`, `cc`, or `bcc` header');
 });
 
 test('message validation succeeds with only `to` recipient header (string)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		to: 'pooh@gmail.com',
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });
 
 test('message validation succeeds with only `to` recipient header (array)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		to: ['pooh@gmail.com'],
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });
 
 test('message validation succeeds with only `cc` recipient header (string)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		cc: 'pooh@gmail.com',
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });
 
 test('message validation succeeds with only `cc` recipient header (array)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		cc: ['pooh@gmail.com'],
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });
 
 test('message validation succeeds with only `bcc` recipient header (string)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		bcc: 'pooh@gmail.com',
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });
 
 test('message validation succeeds with only `bcc` recipient header (array)', async (t) => {
-	const isValid = validate({
+	const { isValid, validationError } = new Message({
 		from: 'piglet@gmail.com',
 		bcc: ['pooh@gmail.com'],
-	});
-	await t.notThrowsAsync(isValid);
-	t.true(await isValid);
+	}).checkValidity();
+
+	t.true(isValid);
+	t.is(validationError, undefined);
 });


### PR DESCRIPTION
it's time to clean it up, i think.

`valid` will be kept for compat purposes, with an eye on removing it in (a completely hypothetical) v4. downstream will be encouraged to switch to the new apis via the `@deprecated` jsdoc tag.

of note: `isValidAsync` will technically never resolve to `false`, which _just feels incorrect_. i'm open to suggestions for changing that design.