### PR TITLE
Seperate type and normal imports

### DIFF
--- a/smtp/client.ts
+++ b/smtp/client.ts
@@ -1,6 +1,8 @@
 import { addressparser } from './address';
-import { Message, MessageAttachment, MessageHeaders } from './message';
-import { SMTPConnection, SMTPConnectionOptions, SMTPState } from './connection';
+import type { MessageAttachment, MessageHeaders } from './message';
+import { Message } from './message';
+import type { SMTPConnectionOptions } from './connection';
+import { SMTPConnection, SMTPState } from './connection';
 
 export type MessageCallback<T = Message | MessageHeaders> = <
 	U extends Error | null,

--- a/smtp/connection.ts
+++ b/smtp/connection.ts
@@ -2,12 +2,8 @@ import { createHmac } from 'crypto';
 import { EventEmitter } from 'events';
 import { Socket } from 'net';
 import { hostname } from 'os';
-import {
-	connect,
-	createSecureContext,
-	ConnectionOptions,
-	TLSSocket,
-} from 'tls';
+import { connect, createSecureContext, TLSSocket } from 'tls';
+import type { ConnectionOptions } from 'tls';
 
 import { SMTPError, SMTPErrorStates } from './error';
 import { SMTPResponseMonitor } from './response';

--- a/smtp/message.ts
+++ b/smtp/message.ts
@@ -1,5 +1,5 @@
+import type { PathLike } from 'fs';
 import {
-	PathLike,
 	existsSync,
 	open as openFile,
 	close as closeFile,

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -1,5 +1,7 @@
-import test, { ExecutionContext } from 'ava';
-import { simpleParser, AddressObject } from 'mailparser';
+import test from 'ava';
+import type { ExecutionContext } from 'ava';
+import { simpleParser } from 'mailparser';
+import type { AddressObject } from 'mailparser';
 import { SMTPServer } from 'smtp-server';
 
 import { AUTH_METHODS, SMTPClient, Message } from '../email';

--- a/test/client.ts
+++ b/test/client.ts
@@ -1,16 +1,12 @@
 import { promisify } from 'util';
 
 import test from 'ava';
-import { simpleParser, ParsedMail, AddressObject } from 'mailparser';
+import { simpleParser } from 'mailparser';
+import type { ParsedMail, AddressObject } from 'mailparser';
 import { SMTPServer } from 'smtp-server';
 
-import {
-	DEFAULT_TIMEOUT,
-	SMTPClient,
-	Message,
-	MessageHeaders,
-	isRFC2822Date,
-} from '../email';
+import type { MessageHeaders } from '../email';
+import { DEFAULT_TIMEOUT, SMTPClient, Message, isRFC2822Date } from '../email';
 
 const parseMap = new Map<string, ParsedMail>();
 const port = 3333;

--- a/test/message.ts
+++ b/test/message.ts
@@ -2,11 +2,14 @@ import { readFileSync, createReadStream } from 'fs';
 import { join } from 'path';
 
 import test from 'ava';
-import { simpleParser, AddressObject, ParsedMail } from 'mailparser';
+import { simpleParser } from 'mailparser';
+import type { AddressObject, ParsedMail } from 'mailparser';
 import { SMTPServer } from 'smtp-server';
 
-import { SMTPClient, Message, MessageAttachment } from '../email';
-import { MessageHeaders } from '../smtp/message';
+import { SMTPClient, Message } from '../email';
+import type { MessageAttachment } from '../email';
+
+import type { MessageHeaders } from '../smtp/message';
 
 // eslint-disable-next-line no-var
 var __dirname: string;


### PR DESCRIPTION
This commit separates imports like
```ts
import { Message, MessageAttachment, MessageHeaders } from './message';
```
to
```ts
import type { MessageAttachment, MessageHeaders } from './message';
import { Message } from './message';
```

this is needed to not throw an Error when using the typescript compiler options:
"preserveValueImports",
"isolatedModules"
 
