### PR TITLE
allow exactOptionalPropertyTypes in tsc 4.8.4

### DIFF
--- a/smtp/address.ts
+++ b/smtp/address.ts
@@ -130,7 +130,7 @@ function convertAddressTokens(tokens: AddressToken[]) {
 	// http://tools.ietf.org/html/rfc2822#appendix-A.1.3
 	if (isGroup) {
 		addressObjects.push({
-			name: texts.length === 0 ? undefined : texts.join(' '),
+			...(texts.length === 0 ? {} : { name: texts.join(' ') }),
 			group: groups.length > 0 ? addressparser(groups.join(',')) : [],
 		});
 	} else {


### PR DESCRIPTION
this leaves out the name property AddressObject instead of setting it to undefined.

typescript 4.4 has a new check exactOptionalPropertyTypes which prevents accidentally confounding a missing property with a property which does exist, but has a value of undefined.

for maximum type safety, i'd like to keep this enabled in my project - but if i do, tsc complains about emailjs being imprecise about its types.