### PR TITLE
fix: avoid node:domain emit crash on connection close

### DIFF
--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -21,7 +21,7 @@ describe('SMTPConnection (Unit)', () => {
 		// Since they are protected, we can just assume they are set if no error.
 		// Or inspect via any:
 		const c = conn as unknown as Record<string, unknown>
-		expect(c.domain).toBe('example.com')
+		expect(c._domain).toBe('example.com')
 		expect(c.host).toBe('mail.example.com')
 		expect(c.ssl).toBe(true)
 		expect(c.tls).toBe(true)
@@ -53,5 +53,14 @@ describe('SMTPConnection (Unit)', () => {
 		})
 		// @ts-expect-error accessing protected
 		expect(conn.tls).toEqual({ rejectUnauthorized: false })
+	})
+
+	it('does not clash with the node:domain emit hook', async () => {
+		// Loading node:domain flips EventEmitter.usingDomains on, which makes
+		// emit() call `this.domain.enter()`. A string `domain` field used to
+		// shadow that and throw `domain.enter is not a function`.
+		await import('node:domain')
+		const conn = new SMTPConnection({ domain: 'example.com' })
+		expect(() => conn.emit('connect')).not.toThrow()
 	})
 })

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -95,7 +95,7 @@ export class SMTPConnection extends EventEmitter {
 	protected sock: Socket | TLSSocket | null = null
 	protected features: { [index: string]: string | boolean } | null = null
 	protected monitor: SMTPResponseMonitor | null = null
-	protected domain = hostname()
+	protected _domain = hostname()
 	protected host = 'localhost'
 	protected ssl: boolean | SMTPSocketOptions = false
 	protected tls: boolean | SMTPSocketOptions = false
@@ -128,7 +128,7 @@ export class SMTPConnection extends EventEmitter {
 		}
 
 		if (typeof domain === 'string') {
-			this.domain = domain
+			this._domain = domain
 		}
 
 		if (typeof host === 'string') {
@@ -393,7 +393,7 @@ export class SMTPConnection extends EventEmitter {
 		callback: (err: Error | null | undefined, data?: unknown) => void,
 		domain?: string
 	) {
-		this.command(`helo ${domain || this.domain}`, (err, data) => {
+		this.command(`helo ${domain || this._domain}`, (err, data) => {
 			if (err) {
 				caller(callback, err)
 			} else {
@@ -468,7 +468,7 @@ export class SMTPConnection extends EventEmitter {
 		domain?: string
 	) {
 		this.features = {}
-		this.command(`ehlo ${domain || this.domain}`, (err, data) => {
+		this.command(`ehlo ${domain || this._domain}`, (err, data) => {
 			if (err) {
 				caller(callback, err)
 			} else {
@@ -585,7 +585,7 @@ export class SMTPConnection extends EventEmitter {
 			method: options?.method?.toUpperCase() ?? '',
 		}
 
-		const domain = options?.domain || this.domain
+		const domain = options?.domain || this._domain
 
 		const initiate = (err: Error | null | undefined, data?: unknown) => {
 			if (err) {


### PR DESCRIPTION
fixes #351

`SMTPConnection extends EventEmitter` but keeps a string `domain` field. Once anything loads the deprecated `node:domain` module (e.g. `node:repl` on node 24, or an explicit import on node 26), `EventEmitter.usingDomains` flips on and `emit()` starts calling `this.domain.enter()`. Because our `domain` is a string, that throws `TypeError: domain.enter is not a function`, which surfaces on `connection.close()` after `sendAsync`.

This renames the internal field to `_domain` so it no longer shadows the property the domain module manages. The public `domain` constructor option is unchanged. Added a regression test that loads `node:domain` and emits an event on a connection.
